### PR TITLE
[sfputil] Add support of platform.json

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -32,7 +32,9 @@ PLATFORM_KEY = 'DEVICE_METADATA.localhost.platform'
 
 # Global platform-specific sfputil class instance
 platform_sfputil = None
-
+PLATFORM_JSON = 'platform.json'
+PORT_CONFIG_INI = 'portconfig.ini'
+PORTMAP_INI = 'portmap.ini'
 
 # ========================== Syslog wrappers ==========================
 
@@ -329,13 +331,15 @@ def get_path_to_port_config_file():
     hwsku_path = "/".join([platform_path, hwsku])
 
     # First check for the presence of the new 'port_config.ini' file
-    port_config_file_path = "/".join([hwsku_path, "port_config.ini"])
+    port_config_file_path = "/".join([hwsku_path, PLATFORM_JSON])
+    if not os.path.isfile(port_config_file_path):
+        # platform.json doesn't exist. Try loading the legacy 'port_config.ini' file
+        port_config_file_path = "/".join([hwsku_path, PORT_CONFIG_INI])
     if not os.path.isfile(port_config_file_path):
         # port_config.ini doesn't exist. Try loading the legacy 'portmap.ini' file
-        port_config_file_path = "/".join([hwsku_path, "portmap.ini"])
+        port_config_file_path = "/".join([hwsku_path, PORTMAP_INI])
 
     return port_config_file_path
-
 
 # Loads platform specific sfputil module from source
 def load_platform_sfputil():


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

> This PR is dependent on [xu/sonic-platform-common/pull/1](https://github.com/zhenggen-xu/sonic-platform-common/pull/1)

**- What I did**
Add support of platform.json in sfputil to get correct output of `show interfaces transceiver`


**- How to verify it**
Check whether all the below-mentioned CLI's are working correctly.
```
Usage: show interfaces transceiver [OPTIONS] COMMAND [ARGS]...

  Show SFP Transceiver information

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  eeprom    Show interface transceiver EEPROM information
  lpmode    Show interface transceiver low-power mode status
  presence  Show interface transceiver presence
```