### PR TITLE
Breakout Cli Bug fix

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1557,6 +1557,9 @@ def breakout(ctx, interface_name, mode, verbose):
             else:
                 click.secho("[ERROR] del_intf_dict is None! No interfaces are there to be deleted", fg='red')
                 raise click.Abort()
+        else:
+            click.secho("[ERROR] {} is not in port_dict".format(interface_name))
+            raise click.Abort()
 
         """ Interface Addition Logic """
         add_intf_dict = _get_child_interface_speed_dict(interface_name, target_brkout_mode, lane_len)
@@ -1578,7 +1581,7 @@ def breakout(ctx, interface_name, mode, verbose):
 
         click.secho("\nFinal list of ports to be deleted : \n {} \nFinal list of ports to be added :  \n {}".format(json.dumps(del_intf_dict, indent=4), json.dumps(add_intf_dict, indent=4), fg='green', blink=True))
         if len(add_intf_dict.keys()) != 0:
-            ports, _ = parse_platform_json_file(BREAKOUT_CFG_FILE, interface_name, target_brkout_mode)
+            ports = parse_platform_json_file(BREAKOUT_CFG_FILE, interface_name, target_brkout_mode)
             port_dict = {}
             for intf in add_intf_dict:
                 if intf in ports.keys():


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

fix a bug in Breakout Cli. Cli is working as usual.
```
admin@lnos-x1-a-fab01:~$ sudo config interface breakout Ethernet4 "2x50G"
Do you want to Breakout the port, continue? [y/N]: y

Running Breakout Mode : 4x25G[10G]
Target Breakout Mode : 2x50G

Ports to be deleted :
 {
    "Ethernet4": "25G",
    "Ethernet5": "25G",
    "Ethernet6": "25G",
    "Ethernet7": "25G"
}
Ports to be added :
 {
    "Ethernet4": "50G",
    "Ethernet6": "50G"
}

After running Logic to limit the impact

Final list of ports to be deleted :
 {
    "Ethernet4": "25G",
    "Ethernet5": "25G",
    "Ethernet6": "25G",
    "Ethernet7": "25G"
}
Final list of ports to be added :
 {
    "Ethernet4": "50G",
    "Ethernet6": "50G"
}
before modification for port Ethernet6
{'alias': ' Eth2/3', 'admin_status': 'down', 'lanes': '6', 'speed': '25G', 'index': '2'}
after modification for port Ethernet6
{'alias': ' Eth2/3', 'admin_status': 'up', 'lanes': '6,7', 'speed': '50G', 'index': '2'}
before modification for port Ethernet4
{'alias': 'Eth2/1', 'admin_status': 'down', 'lanes': '4', 'speed': '25G', 'index': '2'}
after modification for port Ethernet4
{'alias': 'Eth2/1', 'admin_status': 'up', 'lanes': '4,5', 'speed': '50G', 'index': '2'}
PREV Breakout mode for port Ethernet4
{'brkout_mode': '4x25G[10G]'}
CUR Breakout mode for port Ethernet4
{'brkout_mode': '2x50G'}
```