### PR TITLE
Refractored Breakout Mode CLI subcommand with speed fix

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -35,16 +35,6 @@ SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
 SYSLOG_IDENTIFIER = "config"
 PORT_STR = "Ethernet"
 
-
-# Regex for breakout mode
-BRKOUT_PATTERN = r'(\d{1,3})x(\d{1,3}G)(\[\d{1,3}G\])?(\((\d{1,3})\))?'
-
-""" [TODOFIX | IGNORE]: will change the logic like this
-    i.e. BREAKOUT_CFG_FILE = get_path_to_port_config_file(),
-    once the sfputil file gets compatible with platform.json
-"""
-
-
 (platform, hwsku) =  get_platform_and_hwsku()
 BREAKOUT_CFG_FILE = get_port_config_file_name(hwsku, platform)
 
@@ -99,61 +89,6 @@ def readJsonFile(fileName):
         raise Exception(str(e))
     return result
 
-
-def _get_child_interface_speed_dict(intf, brkout_mode, lane_len):
-    """
-    Returns list of interfaces needed to be deleted or added
-    to change from  running breakout mode to target breakout mode
-    """
-
-    try:
-        parent_intf_id = re.search("Ethernet(\d+)", intf)
-        if parent_intf_id is not None:
-            id = parent_intf_id.group(1)
-        else:
-            raise Exception("parent interface index should not be None.")
-    except re.error as e:
-        raise Exception("Invalid regular expression: {}\n Error: {}".format(e.args[0]), e)
-
-    # Logic for ASYMMETRIC breakout mode
-    if re.search("\+",brkout_mode) is not None:
-        brkout_parts = brkout_mode.split("+")
-        match_list = [re.match(BRKOUT_PATTERN, i).groups() for i in brkout_parts]
-        if match_list is not None:
-            intf_del_list = []
-            for k in match_list:
-                num_lane_used, speed, alt_speed, assigned_lane = k[0], k[1], k[2], k[4]
-                if assigned_lane and num_lane_used:
-                    if intf_del_list:
-                        intf_del_list = [PORT_STR+str(int(id)+int(i)) for i in range(0, int(assigned_lane), int(assigned_lane)/int(num_lane_used))]
-                        child_intf_dict.update(OrderedDict(( i, speed.encode("utf-8")) for i in intf_del_list))
-                    else:
-                        intf_del_list = [PORT_STR+str(int(id)+int(i)) for i in range(0, int(assigned_lane), int(assigned_lane)/int(num_lane_used))]
-                        child_intf_dict =  OrderedDict(( i, speed.encode("utf-8")) for i in intf_del_list)
-                    id = int(id) + int(str(assigned_lane))
-                else:
-                    raise Exception('Not found...')
-        else:
-            raise Exception("match_list should not be None.")
-
-    # Logic for SYMMETRIC breakout mode
-    else:
-        match_list = [re.match(BRKOUT_PATTERN, brkout_mode).groups()]
-        if match_list is not None:
-            num_lane_used = match_list[0][0]
-            if num_lane_used:
-                intf_del_list = [PORT_STR+str(int(id)+int(i)) for i in range(0,int(lane_len), int(lane_len)/int(num_lane_used))]
-            else:
-                raise Exception('Not found...')
-        else:
-            raise Exception("match_list should not be None.")
-        if intf_del_list:
-            child_intf_dict =  OrderedDict(( i, match_list[0][1]) for i in intf_del_list)
-        else:
-            raise Exception('Not Found the list of delete interfaces ')
-    return child_intf_dict
-
-
 def _get_option(ctx,args,incomplete):
     """ Provides dynamic mode option as per user argument i.e. interface name """
     global all_mode_options
@@ -171,8 +106,6 @@ def _get_option(ctx,args,incomplete):
                     breakout_mode_options.append(i)
             all_mode_options = [str(c) for c in breakout_mode_options if incomplete in c]
             return all_mode_options
-
-
 
 #
 # Helper functions
@@ -1535,7 +1468,8 @@ def breakout(ctx, interface_name, mode, verbose):
                 sys.exit(0)
 
             # Get list of interfaces to be deleted
-            del_intf_dict = _get_child_interface_speed_dict(interface_name, cur_brkout_mode,lane_len )
+            del_ports = parse_platform_json_file(BREAKOUT_CFG_FILE, interface_name, target_brkout_mode=cur_brkout_mode)
+            del_intf_dict = {intf: del_ports[intf]["speed"] for intf in del_ports}
             if del_intf_dict:
                 for intf in del_intf_dict.keys():
                     # First, Shut down interface
@@ -1562,7 +1496,8 @@ def breakout(ctx, interface_name, mode, verbose):
             raise click.Abort()
 
         """ Interface Addition Logic """
-        add_intf_dict = _get_child_interface_speed_dict(interface_name, target_brkout_mode, lane_len)
+        add_ports = parse_platform_json_file(BREAKOUT_CFG_FILE, interface_name, target_brkout_mode=target_brkout_mode)
+        add_intf_dict = {intf: add_ports[intf]["speed"] for intf in add_ports}
         if add_intf_dict:
             click.echo("Ports to be added : \n {}".format(json.dumps(add_intf_dict, indent=4)))
         else:
@@ -1581,11 +1516,10 @@ def breakout(ctx, interface_name, mode, verbose):
 
         click.secho("\nFinal list of ports to be deleted : \n {} \nFinal list of ports to be added :  \n {}".format(json.dumps(del_intf_dict, indent=4), json.dumps(add_intf_dict, indent=4), fg='green', blink=True))
         if len(add_intf_dict.keys()) != 0:
-            ports = parse_platform_json_file(BREAKOUT_CFG_FILE, interface_name, target_brkout_mode)
             port_dict = {}
             for intf in add_intf_dict:
-                if intf in ports.keys():
-                    port_dict[intf] = ports[intf]
+                if intf in add_ports.keys():
+                    port_dict[intf] = add_ports[intf]
 
             with open('new_port_config.json', 'w') as f:  # writing JSON object
                 json.dump(port_dict, f, indent=4)


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>


**- What I did**
Refactored the code. Removed a function that is not needed anymore. Speed is now properly populated via portconfig.py

This PR is dependent on  [portconfig.py](https://github.com/zhenggen-xu/sonic-buildimage/pull/17/files) file in  sonic-buildimage

**- How I did it**
using portconfig.py in sonic build image.

- How to verify it
Verified using VS test case mentioned [here](https://github.com/zhenggen-xu/sonic-buildimage/pull/18)

```

samaity@server09:~/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/platform/vs/tests/breakout$ sudo pytest -s -v --dvsname=vs-sang test_breakout_cli.py
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/platform/vs/tests/breakout, inifile:
collected 2 items

test_breakout_cli.py::TestBreakoutCli::test_InitialBreakoutMode remove extra link dummy
PASSED                                                                                      [ 50%]
test_breakout_cli.py::TestBreakoutCli::test_mode_1X100G **** Breakout Cli test Starts ****
**** 1X100G --> 2x50G passed ****
**** 2x50G --> 1x100G[40G] passed ****
**** 1X100G --> 4x25G[10G] passed ****
**** 4x25G[10G] --> 1x100G[40G] passed ****
**** 1x100G[40G] --> 2x25G(2)+1x50G(2) passed ****
**** 2x25G(2)+1x50G(2) --> 1x100G[40G] passed ****
**** 1x100G[40G] --> 1x50G(2)+2x25G(2)  passed ****
**** 1x50G(2)+2x25G(2) --> 1x100G[40G] passed ****
**** 1x100G[40G] --> 2x50G  passed ****
**** 2x50G --> 2x25G(2)+1x50G(2)  passed ****
**** 1x50G(2)+2x25G(2) --> 2x25G(2)+1x50G(2)  passed ****
**** 2x25G(2)+1x50G(2)  --> 1x100G[40G]  passed ****
PASSED                                                                                              [100%]
```