### PR TITLE
[main.py]: Verify from Asic DB that Port are deleted.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1655,7 +1655,7 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
      Internal Function:  Check ASIC DB whether interfaces present or not
      ports: List of ports
      presence: If False, Make sure Ports are not present, return False otherwise.
-               If True, Make sure Ports are present, return True otherwise.
+               If True, Make sure Ports are present, return False otherwise.
     """
     def check_Ports_AsicDb(db, ports, presence, portMap):
 
@@ -1667,7 +1667,7 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
 
             for port in ports:
                 oid = portMap.get(port)
-                print("For Testing [Check Asic DB] {}:{}".format(port, oid))
+                #print("For Testing [Check Asic DB] {}:{}".format(port, oid))
                 # If Presence == False but entry exists, return False
                 if presence == False and oidDict.get(oid):
                     return False
@@ -1682,13 +1682,13 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
 
     MAX_WAIT = 60
     click.secho("\nVerify Port Deletion from Asic DB, Wait...", fg="cyan")
-    for waitTime in xrange(MAX_WAIT):
+    for waitTime in range(MAX_WAIT):
         if check_Ports_AsicDb(db=dataBase, ports=final_delPorts, \
             presence=False, portMap=if_name_map):
             break
         if waitTime == MAX_WAIT:
             click.secho("\nCritical Failure, Ports are not Deleted from \
-                Asic DB, Bail Out", fg="cyan")
+                ASIC DB, Bail Out", fg="cyan")
         time.sleep(1)
 
     """ Add ports with its attributes using configMgmt API """

--- a/config/main.py
+++ b/config/main.py
@@ -14,7 +14,7 @@ import netifaces
 import sonic_device_util
 import ipaddress
 from swsssdk import ConfigDBConnector
-from swsssdk import SonicV2Connector
+from swsssdk import SonicV2Connector, port_util
 from minigraph import parse_device_desc_xml
 from config_mgmt import configMgmt
 
@@ -1642,12 +1642,54 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
 
     """ Load config for the commands which are capable of change in config DB """
     cm = load_configMgmt(verbose)
+
+    """ Save Port OIDs Mapping Before Deleting Port"""
+    dataBase = SonicV2Connector(host="127.0.0.1")
+    if_name_map, if_oid_map = port_util.get_interface_oid_map(dataBase)
+
     """ Delete all ports if forced else print dependencies using configMgmt API """
     final_delPorts = [intf for intf in del_intf_dict.keys()]
     delete_Ports(cm, final_delPorts, force_remove_dependencies, verbose)
 
-    # TODOFIX:  Check ASIC DB whether interfaces got deleted or not
-    time.sleep(5)
+    """
+     Internal Function:  Check ASIC DB whether interfaces present or not
+     ports: List of ports
+     presence: If False, Make sure Ports are not present, return False otherwise.
+               If True, Make sure Ports are present, return True otherwise.
+    """
+    def check_Ports_AsicDb(db, ports, presence, portMap):
+
+        try:
+            db.connect(db.ASIC_DB)
+            oidKey = 'ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x*'
+            oidDict = {oids.strip(oidKey):True for oids in \
+                db.keys('ASIC_DB', oidKey)}
+
+            for port in ports:
+                oid = portMap.get(port)
+                print("For Testing [Check Asic DB] {}:{}".format(port, oid))
+                # If Presence == False but entry exists, return False
+                if presence == False and oidDict.get(oid):
+                    return False
+                # If Presence == True and entry does not exists, return False
+                elif presence and oidDict.get(oid) == None:
+                    return False
+        except Exception as e:
+            print(e)
+            return False
+
+        return True
+
+    MAX_WAIT = 60
+    click.secho("\nVerify Port Deletion from Asic DB, Wait...", fg="cyan")
+    for waitTime in xrange(MAX_WAIT):
+        if check_Ports_AsicDb(db=dataBase, ports=final_delPorts, \
+            presence=False, portMap=if_name_map):
+            break
+        if waitTime == MAX_WAIT:
+            click.secho("\nCritical Failure, Ports are not Deleted from \
+                Asic DB, Bail Out", fg="cyan")
+        time.sleep(1)
 
     """ Add ports with its attributes using configMgmt API """
     final_addPorts = [intf for intf in port_dict.keys()]


### PR DESCRIPTION
Wait Max for a min.

An internal function is written, which will move to config_mgmt.py
file once delete Port and add Port APIs are merged.

Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Verify Asic DB entries after Port Deletion.

**- How I did it**
Using SonicV2Connector and Port Util APIs.

**- How to verify it**
Test Logs:
```
Testing:
Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Deleting Port: Ethernet2
Deleting Port: Ethernet3
Deleting Port: Ethernet0
Deleting Port: Ethernet1
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB

*** Ports have been deleted successfully ***


Verify Port Deletion from Asic DB, Wait...
For Testing [Check Asic DB] Ethernet2:1000000001aa3
For Testing [Check Asic DB] Ethernet2:1000000001aa3
For Testing [Check Asic DB] Ethernet3:1000000001acc
For Testing [Check Asic DB] Ethernet0:1000000001a51
For Testing [Check Asic DB] Ethernet1:1000000001a7a

Start Port Addition
Generating default config for ['Ethernet2', 'Ethernet0']
Merge Port Config for ['Ethernet2', 'Ethernet0']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB

*** Ports have been added successfully ***

Breakout process got successfully completed.
admin@lnos-x1-a-asw01:~/pc_testing$
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

