### PR TITLE
[config_mgmt.py]: 1.) Merge Del and Add APIs as breakOut API.

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -137,7 +137,7 @@ class configMgmt():
         self.logInFile('Check Key in Asic DB: {}'.format(key))
         try:
             # chk key in ASIC DB
-            if oid and db.exists('ASIC_DB', key):
+            if db.exists('ASIC_DB', key):
                 return True
         except Exception as e:
             print(e)

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -9,13 +9,14 @@ try:
     from imp import load_source
     load_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
     from sonic_cfggen import deep_update, FormatConverter, sort_data
-    from swsssdk import ConfigDBConnector
+    from swsssdk import ConfigDBConnector, SonicV2Connector, port_util
     from pprint import PrettyPrinter, pprint
     from json import dump, load, dumps, loads
     from sys import path as sysPath
     from os import path as osPath
     from os import system
     from datetime import datetime
+    from time import sleep as tsleep
 
     import sonic_yang
     import re
@@ -36,16 +37,17 @@ DEFAULT_CONFIG_DB_JSON_FILE = '/etc/sonic/default_config_db.json'
 
 class configMgmt():
 
-    def __init__(self, source="configDB", debug=False):
+    def __init__(self, source="configDB", debug=False, allowExtraTables=True):
 
         try:
             self.configdbJsonIn = None
             self.configdbJsonOut = None
+            self.allowExtraTables = allowExtraTables
 
             self.DEBUG_FILE = None
             if debug:
                 self.DEBUG_FILE = '_debug_config_mgmt'
-                with open(self.DEBUG_FILE, 'w') as df:
+                with open(self.DEBUG_FILE, 'a') as df:
                     df.write('--- Start config_mgmt logging ---\n\n')
 
             self.sy = sonic_yang.sonic_yang(YANG_DIR, debug=debug)
@@ -60,7 +62,7 @@ class configMgmt():
                 self.readConfigDBJson(source)
 
             # this will crop config, xlate and load.
-            self.sy.load_data(self.configdbJsonIn)
+            self.sy.load_data(self.configdbJsonIn, self.allowExtraTables)
 
         except Exception as e:
             print(e)
@@ -107,9 +109,139 @@ class configMgmt():
         configdb.connect()
         deep_update(data, FormatConverter.db_to_output(configdb.get_config()))
         self.configdbJsonIn =  FormatConverter.to_serialized(data)
-        self.logInFile('Reading Input', self.configdbJsonIn, True)
+        #self.logInFile('Reading Input', self.configdbJsonIn, True)
 
         return
+
+    def writeConfigDB(self, jDiff):
+        print('Writing in Config DB')
+        """
+        On Sonic Switch
+        """
+        db_kwargs = dict(); data = dict()
+        configdb = ConfigDBConnector(**db_kwargs)
+        configdb.connect(False)
+        deep_update(data, FormatConverter.to_deserialized(jDiff))
+        data = sort_data(data)
+        self.logInFile("Write in DB: Last Data\n", data)
+        configdb.mod_config(FormatConverter.output_to_db(data))
+
+        return
+
+    """
+     Check ASIC DB whether interfaces present or not
+     ports: List of ports
+     portMap: port to OID map.
+     Return: True if all ports are not present.
+    """
+    def checkPortsInAsicDb(self, db, ports, portMap):
+
+        # internal funtions for better testing
+        def testAsicDB(oid):
+            # To Debug
+            if self.DEBUG_FILE:
+                cmd = 'sudo redis-cli -n 1 hgetall ' + \
+                '"ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x{}"'.format(oid)
+                print(cmd)
+                self.logInFile("Running {}".format(cmd))
+                system(cmd)
+            return
+
+        try:
+            # connect to ASIC DB,
+            db.connect(db.ASIC_DB)
+            oidKey = 'ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x'
+
+            for port in ports:
+                portExist = True
+                # Get Oid
+                oid = portMap.get(port)
+                self.logInFile('Asic DB chk: port {} oid {}'.format(port, oid))
+                # chk oid in ASIC DB
+                if oid and not db.exists('ASIC_DB', oidKey + oid):
+                    portExist = False
+                    self.logInFile('Asic DB chk: port {} is not present'.format(\
+                        port, oid))
+                    testAsicDB(oid)
+
+                # Fail if any port Exist
+                if portExist:
+                    return False
+
+        except Exception as e:
+            print(e)
+            return False
+
+        return True
+
+    """
+    Verify in the Asic DB that port are deleted,
+    Keep on trying till timeout period.
+    db = database, ports, portMap, timeout
+    """
+    def verifyAsicDB(self, db, ports, portMap, timeout):
+
+        print("Verify Port Deletion from Asic DB, Wait...")
+        self.logInFile("Verify Port Deletion from Asic DB, Wait...")
+
+        try:
+            for waitTime in range(timeout):
+                # checkPortsInAsicDb will return True only when all ports are not
+                # present
+                self.logInFile('Check Asic DB: {} try'.format(waitTime+1))
+                if self.checkPortsInAsicDb(db, ports, portMap):
+                    break
+                if waitTime + 1 == timeout:
+                    print("!!!  Critical Failure, Ports are not Deleted from \
+                        ASIC DB, Bail Out  !!!")
+                    self.logInFile("!!!  Critical Failure, Ports are not Deleted from \
+                        ASIC DB, Bail Out  !!!")
+                    raise(Exception("Ports are present in ASIC DB after timeout"))
+                tsleep(1)
+        except Exception as e:
+            print(e)
+            raise e
+
+        return True
+
+    def breakOutPort(self, delPorts=list(), addPorts= list(), portJson=dict(), \
+        force=False, loadDefConfig=True):
+
+        MAX_WAIT = 60
+        try:
+            # delete Port and get the Config diff, deps and True/False
+            delConfigToLoad, deps, ret = self.deletePorts(ports=delPorts, \
+                force=force)
+            # return dependencies if delete port fails
+            if ret == False:
+                return deps, ret
+
+            # add Ports and get the config diff and True/False
+            addConfigtoLoad, ret = self.addPorts(ports=addPorts, \
+                portJson=portJson, loadDefConfig=loadDefConfig)
+            # return if ret is False, Great thing, no change is done in Config
+            if ret == False:
+                return None, ret
+
+            # Save Port OIDs Mapping Before Deleting Port
+            dataBase = SonicV2Connector(host="127.0.0.1")
+            if_name_map, if_oid_map = port_util.get_interface_oid_map(dataBase)
+            self.logInFile('if_name_map', obj=if_name_map, json=True)
+
+            # If we are here, then get ready to update the Config DB, Update
+            # deletion of Config first, then verify in Asic DB for port deletion,
+            # then update addition of ports in config DB.
+            self.writeConfigDB(delConfigToLoad)
+            # Verify in Asic DB,
+            self.verifyAsicDB(db=dataBase, ports=delPorts, portMap=if_name_map, \
+                timeout=MAX_WAIT)
+            self.writeConfigDB(addConfigtoLoad)
+
+        except Exception as e:
+            print(e)
+            return None, False
+
+        return None, True
 
     """
     Delete all ports.
@@ -120,27 +252,30 @@ class configMgmt():
     WithOut Force: (xpath of dependecies, False) or (None, True)
     With Force: (xpath of dependecies, False) or (None, True)
     """
-    def deletePorts(self, delPorts=list(), force=False):
+    def deletePorts(self, ports=list(), force=False):
 
+        configToLoad = None; deps = None
         try:
-            self.logInFile("delPorts ports:{} force:{}".format(delPorts, force))
+            self.logInFile("delPorts ports:{} force:{}".format(ports, force))
 
             print('\nStart Port Deletion')
             deps = list()
 
             # Get all dependecies for ports
-            for port in delPorts:
+            for port in ports:
                 xPathPort = self.sy.findXpathPortLeaf(port)
                 print('Find dependecies for port {}'.format(port))
+                self.logInFile('Find dependecies for port {}'.format(port))
                 # print("Generated Xpath:" + xPathPort)
                 dep = self.sy.find_data_dependencies(str(xPathPort))
                 if dep:
                     deps.extend(dep)
             self.logInFile('Dependencies', deps)
 
+
             # No further action with no force and deps exist
             if force == False and deps:
-                return deps, False;
+                return configToLoad, deps, False;
 
             # delets all deps, No topological sort is needed as of now, if deletion
             # of deps fails, return immediately
@@ -148,9 +283,11 @@ class configMgmt():
                 for dep in deps:
                     self.logInFile('Deleting', dep)
                     self.sy.delete_node(str(dep))
+            # mark deps as None now,
+            deps = None
 
             # all deps are deleted now, delete all ports now
-            for port in delPorts:
+            for port in ports:
                 xPathPort = self.sy.findXpathPort(port)
                 print("Deleting Port: " + port)
                 self.logInFile('Deleting Port:{}'.format(port), xPathPort)
@@ -158,18 +295,19 @@ class configMgmt():
 
             # Let`s Validate the tree now
             if self.validateConfigData()==False:
-                return None, False
+                return configToLoad, deps, False;
 
-            # All great if we are here, Lets get the diff and update Config
+            # All great if we are here, Lets get the diff
             self.configdbJsonOut = self.sy.get_data()
-            self.updateDiffConfigDB()
+            # Update configToLoad
+            configToLoad = self.updateDiffConfigDB()
 
         except Exception as e:
             print(e)
             print("Port Deletion Failed")
-            return deps, False
+            return configToLoad, deps, False
 
-        return None, True
+        return configToLoad, deps, True
 
     """
     Add Ports and default config for ports to config DB, after validation of
@@ -183,7 +321,9 @@ class configMgmt():
     """
     def addPorts(self, ports=list(), portJson=dict(), loadDefConfig=True):
 
+        configToLoad = None
         try:
+            self.logInFile('\nStart Port Addition')
             self.logInFile("addPorts ports:{} loadDefConfig:{}".format(ports, loadDefConfig))
             self.logInFile("addPorts Args portjson: ", portJson)
 
@@ -196,11 +336,6 @@ class configMgmt():
                     defConfig, json=True)
             #prtprint(defConfig)
 
-            # Merge PortJson and default config
-            portJson.update(defConfig)
-            defConfig = None
-            #prtprint(portJson)
-
             # get the latest Data Tree, save this in input config, since this
             # is our starting point now
             self.configdbJsonIn = self.sy.get_data()
@@ -209,24 +344,30 @@ class configMgmt():
             if self.configdbJsonOut is None:
                 self.configdbJsonOut = self.sy.get_data()
 
-            # merge new config with data tree, this is json level merge
-            print("Merge Port Config for {}".format(ports))
-            self.mergeConfigs(self.configdbJsonOut, portJson)
+            # update portJson in configdbJsonOut PORT part
+            self.configdbJsonOut['PORT'].update(portJson['PORT'])
+            # merge new config with data tree, this is json level merge.
+            # We do not allow new table merge while adding default config.
+            if loadDefConfig:
+                print("Merge Default Config for {}".format(ports))
+                self.logInFile("Merge Default Config for {}".format(ports))
+                self.mergeConfigs(self.configdbJsonOut, defConfig, True)
+
             # create a tree with merged config and validate, if validation is
             # sucessful, then configdbJsonOut contains final and valid config.
-            self.sy.load_data(self.configdbJsonOut)
+            self.sy.load_data(self.configdbJsonOut, self.allowExtraTables)
             if self.validateConfigData()==False:
-                return False
+                return configToLoad, False
 
             # All great if we are here, Let`s get the diff and update COnfig
-            self.updateDiffConfigDB()
+            configToLoad = self.updateDiffConfigDB()
 
         except Exception as e:
             print(e)
             print("Port Addition Failed")
-            return False
+            return configToLoad, False
 
-        return True
+        return configToLoad, True
 
     """
     Validate current Data Tree
@@ -236,17 +377,20 @@ class configMgmt():
         try:
             self.sy.validate_data_tree()
         except Exception as e:
+            self.logInFile('Data Validation Failed')
             return False
 
         print('Data Validation successful')
+        self.logInFile('Data Validation successful')
         return True
 
     """
     Merge second dict in first, Note both first and second dict will be changed
     First Dict will have merged part D1 + D2
     Second dict will have D2 - D1 [unique keys in D2]
+    Unique keys in D2 will be merged in D1 only if uniqueKeys=True
     """
-    def mergeConfigs(self, D1, D2):
+    def mergeConfigs(self, D1, D2, uniqueKeys=True):
 
         try:
             def mergeItems(it1, it2):
@@ -274,8 +418,9 @@ class configMgmt():
                 else:
                     pass
 
-            # merge rest of the keys in D1
-            D1.update(D2)
+            # if uniqueKeys are needed, merge rest of the keys of D2 in D1
+            if uniqueKeys:
+                D1.update(D2)
         except Exce as e:
             print("Merge Config failed")
             print(e)
@@ -349,45 +494,24 @@ class configMgmt():
 
     def updateDiffConfigDB(self):
 
-        ### Internal Functions ###
-        def writeConfigDB(jDiff):
-            print('Writing in Config DB')
-            """
-            On Sonic Switch
-            """
-            db_kwargs = dict(); data = dict()
-            configdb = ConfigDBConnector(**db_kwargs)
-            configdb.connect(False)
-            deep_update(data, FormatConverter.to_deserialized(jDiff))
-            data = sort_data(data)
-            self.logInFile("Write in DB: Last Data", data)
-            configdb.mod_config(FormatConverter.output_to_db(data))
-
-            return
-
         # main code starts here
+        configToLoad = dict()
         try:
             # Get the Diff
             print('Generate Final Config to write in DB')
             configDBdiff = self.diffJson()
-            #print("\n***Config Diff***\n")
-            #prtprint(configDBdiff)
 
             # Process diff and create Config which can be updated in Config DB
             configToLoad = self.createConfigToLoad(configDBdiff, \
                 self.configdbJsonIn, self.configdbJsonOut)
-            #print("\n***Config To Load***\n")
-            #prtprint(configToLoad)
-
-            #Write to Config DB now
-            writeConfigDB(configToLoad)
+            self.logInFile("Config Diff to Load: {}", configToLoad, True)
 
         except Exception as e:
             print("Update to Config DB Failed")
             print(e)
             raise e
 
-        return
+        return configToLoad
 
     """
     Create the config to write in Config DB from json diff

--- a/config/main.py
+++ b/config/main.py
@@ -14,7 +14,7 @@ import netifaces
 import sonic_device_util
 import ipaddress
 from swsssdk import ConfigDBConnector
-from swsssdk import SonicV2Connector, port_util
+from swsssdk import SonicV2Connector
 from minigraph import parse_device_desc_xml
 from config_mgmt import configMgmt
 
@@ -164,57 +164,32 @@ def _validate_interface_mode(ctx, BREAKOUT_CFG_FILE, interface_name, target_brko
 def load_configMgmt(verbose):
     """ Load config for the commands which are capable of change in config DB. """
     try:
-        cm = configMgmt(debug=verbose)
+        # TODO: set allowExtraTables to False, i.e we should have yang models for
+        # each table in Config. [TODO: Create Yang model for each Table]
+        # cm = configMgmt(debug=verbose, allowExtraTables=False)
+        cm = configMgmt(debug=verbose, allowExtraTables=True)
         return cm
     except Exception as e:
-        raise Exception("Failed to load the config. Error: {}".str(e))
+        raise Exception("Failed to load the config. Error: {}".format(str(e)))
 
+def breakout_Ports(cm, delPorts=list(), addPorts=list(), portJson=dict(), \
+    force=False, loadDefConfig=True, verbose=False):
 
-def delete_Ports(cm, final_delPorts,force_remove_dependencies, verbose):
-    """
-    Delete all ports.
-    del_ports: list of port names.
-    force_remove_dependencies: if false return dependecies, else delete dependencies.
-    Return:
-        WithOut Force: (xpath of dependecies, False) or (None, True)
-        With Force: (xpath of dependecies, False) or (None, True)
-    """
-    deps, ret = cm.deletePorts(delPorts=final_delPorts, force=force_remove_dependencies)
-    # No further action with no force and deps exist
-    if not force_remove_dependencies:
-        if ret == False and deps:
+    deps, ret = cm.breakOutPort(delPorts=delPorts, addPorts = addPorts, \
+                    portJson=portJson, force=force, loadDefConfig=loadDefConfig)
+    # check if DPB failed
+    if ret == False:
+        if not force and deps:
             print("Dependecies Exist. No further action will be taken")
-            print("\n*** Printing dependecies ***\n {}".format(deps))
+            print("*** Printing dependecies ***")
+            for dep in deps:
+                print(dep)
             sys.exit(0)
-    if ret == False and deps:
-        print("[ERROR] Port Deletion failed!!! Opting Out")
-        raise click.Abort()
-
-    print("\n*** Ports have been deleted successfully ***\n")
-
-
-def add_Ports(cm, final_addPorts, port_dict, load_predefined_config, verbose):
-    """
-    Add Ports and default config for ports to config DB, after validation of data tree.
-    add_ports : list of ports
-    port_dict : Config DB Json Part of all Ports same as PORT Table of Config DB.
-    load_predefined_config : If True, add default config as well.
-    return:
-        Sucess: True or Failure: False
-    """
-    try:
-        # addPorts API expect PORT table
-        portJson = dict(); portJson['PORT'] = port_dict
-        ret = cm.addPorts(ports=final_addPorts, portJson=portJson, \
-                          loadDefConfig=load_predefined_config)
-        if ret == False:
-            print("[ERROR] Port Addition failed!!! Required User intervention")
+        else:
+            print("[ERROR] Port breakout Failed!!! Opting Out")
             raise click.Abort()
-    except Exception as e:
-        raise Exception("[ERROR] Failed to load addPorts API. Error:")
 
-    print("\n*** Ports have been added successfully ***\n")
-
+        return
 #
 # Helper functions
 #
@@ -1642,68 +1617,38 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
     with open('new_port_config.json', 'w') as f:
         json.dump(port_dict, f, indent=4)
 
-    """ Load config for the commands which are capable of change in config DB """
-    cm = load_configMgmt(verbose)
+    # Start Interation with Dy Port BreakOut Config Mgmt
+    try:
+        """ Load config for the commands which are capable of change in config DB """
+        cm = load_configMgmt(verbose)
 
-    """ Save Port OIDs Mapping Before Deleting Port"""
-    dataBase = SonicV2Connector(host="127.0.0.1")
-    if_name_map, if_oid_map = port_util.get_interface_oid_map(dataBase)
+        """ Delete all ports if forced else print dependencies using configMgmt API """
+        final_delPorts = [intf for intf in del_intf_dict.keys()]
+        #delete_Ports(cm, final_delPorts, force_remove_dependencies, verbose)
+        """ Add ports with its attributes using configMgmt API """
+        final_addPorts = [intf for intf in port_dict.keys()]
+        #add_Ports(cm, final_addPorts, port_dict, load_predefined_config, verbose)
+        portJson = dict(); portJson['PORT'] = port_dict
+        # breakout_Ports will abort operation on failure, So no need to check return
+        breakout_Ports(cm, delPorts=final_delPorts, addPorts = final_addPorts, \
+            portJson=portJson, force=force_remove_dependencies, \
+            loadDefConfig=load_predefined_config, verbose=verbose)
 
-    """ Delete all ports if forced else print dependencies using configMgmt API """
-    final_delPorts = [intf for intf in del_intf_dict.keys()]
-    delete_Ports(cm, final_delPorts, force_remove_dependencies, verbose)
+        # Set Current Breakout mode in config DB
+        brkout_cfg_keys = config_db.get_keys('BREAKOUT_CFG')
+        if interface_name.decode("utf-8") not in  brkout_cfg_keys:
+            click.secho("[ERROR] {} is not present in 'BREAKOUT_CFG' Table!".\
+                format(interface_name), fg='red')
+            raise click.Abort()
+        config_db.set_entry("BREAKOUT_CFG", interface_name,\
+            {'brkout_mode': target_brkout_mode})
+        click.secho("Breakout process got successfully completed.".\
+            format(interface_name),  fg="cyan", underline=True)
 
-    """
-     Internal Function:  Check ASIC DB whether interfaces present or not
-     ports: List of ports
-     presence: If False, Make sure Ports are not present, return False otherwise.
-               If True, Make sure Ports are present, return False otherwise.
-    """
-    def check_Ports_AsicDb(db, ports, presence, portMap):
-
-        try:
-            db.connect(db.ASIC_DB)
-            oidKey = 'ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x*'
-            oidDict = {oids.strip(oidKey):True for oids in \
-                db.keys('ASIC_DB', oidKey)}
-
-            for port in ports:
-                oid = portMap.get(port)
-                #print("For Testing [Check Asic DB] {}:{}".format(port, oid))
-                # If Presence == False but entry exists, return False
-                if presence == False and oidDict.get(oid):
-                    return False
-                # If Presence == True and entry does not exists, return False
-                elif presence and oidDict.get(oid) == None:
-                    return False
-        except Exception as e:
-            print(e)
-            return False
-
-        return True
-
-    MAX_WAIT = 60
-    click.secho("\nVerify Port Deletion from Asic DB, Wait...", fg="cyan")
-    for waitTime in range(MAX_WAIT):
-        if check_Ports_AsicDb(db=dataBase, ports=final_delPorts, \
-            presence=False, portMap=if_name_map):
-            break
-        if waitTime == MAX_WAIT:
-            click.secho("\nCritical Failure, Ports are not Deleted from \
-                ASIC DB, Bail Out", fg="cyan")
-        time.sleep(1)
-
-    """ Add ports with its attributes using configMgmt API """
-    final_addPorts = [intf for intf in port_dict.keys()]
-    add_Ports(cm, final_addPorts, port_dict, load_predefined_config, verbose)
-
-    # Set Current Breakout mode in config DB
-    brkout_cfg_keys = config_db.get_keys('BREAKOUT_CFG')
-    if interface_name.decode("utf-8") not in  brkout_cfg_keys:
-        click.secho("[ERROR] {} is not present in 'BREAKOUT_CFG' Table!".format(interface_name), fg='red')
-        raise click.Abort()
-    config_db.set_entry("BREAKOUT_CFG", interface_name,{'brkout_mode': target_brkout_mode})
-    click.secho("Breakout process got successfully completed.".format(interface_name),  fg="cyan", underline=True)
+    except Exception as e:
+        click.secho("Failed to break out Port. Error: {}".format(str(e)), \
+            fg='magenta')
+        sys.exit(0)
 
 
 def _get_all_mgmtinterface_keys():

--- a/config/main.py
+++ b/config/main.py
@@ -1624,10 +1624,8 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
 
         """ Delete all ports if forced else print dependencies using configMgmt API """
         final_delPorts = [intf for intf in del_intf_dict.keys()]
-        #delete_Ports(cm, final_delPorts, force_remove_dependencies, verbose)
         """ Add ports with its attributes using configMgmt API """
         final_addPorts = [intf for intf in port_dict.keys()]
-        #add_Ports(cm, final_addPorts, port_dict, load_predefined_config, verbose)
         portJson = dict(); portJson['PORT'] = port_dict
         # breakout_Ports will abort operation on failure, So no need to check return
         breakout_Ports(cm, delPorts=final_delPorts, addPorts = final_addPorts, \


### PR DESCRIPTION
To verify entire config first before any update to config DB.

2.) Do not allow extra tables in config during dynamic port breakout command, but allow with config reload\load.

3.) Verify Config in Asic DB, Double check with -v option by redis-cli command.

4.) Print Dependencies in separate lines.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
[config_mgmt.py]: 1.) Merge Del and Add APIs as breakOut API.

To verify entire config first before any update to config DB.

2.) Do not allow extra tables in config during dynamic port breakout command, but allow with config reload\load.

3.) Verify Config in Asic DB, Double check with -v option by redis-cli command.

4.) Print Dependencies in separate lines.


**- How I did it**

Created a new breakOutPort API which calls deletePorts and addPorts. New API breakOutPort updates config to config DB only after del and add verification. It also verifies PORT in ASIC DB after port deletion and before port addition

**- How to verify it**

>>>>> Test with out -f option to show dependencies.
```
admin@lnos-x1-a-asw01:~$ date
Fri Jan 31 20:49:59 UTC 2020
admin@lnos-x1-a-asw01:~$ sudo config interface breakout Ethernet0 2x50G  -l -v -y


}
Loaded below Yang Models
['sonic-acl', 'sonic-head', 'sonic-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Dependecies Exist. No further action will be taken
*** Printing dependecies ***
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan100']/members[.='Ethernet2']
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan777']/members[.='Ethernet2']
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan100'][port='Ethernet2']/port
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan777'][port='Ethernet2']/port
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan100']/members[.='Ethernet3']
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan777']/members[.='Ethernet3']
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan100'][port='Ethernet3']/port
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan777'][port='Ethernet3']/port
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan100']/members[.='Ethernet0']
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan777']/members[.='Ethernet0']
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan100'][port='Ethernet0']/port
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan777'][port='Ethernet0']/port
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan100']/members[.='Ethernet1']
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan777']/members[.='Ethernet1']
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan100'][port='Ethernet1']/port
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan777'][port='Ethernet1']/port

```

>>>>> Test with only -f option  From 25G to 50G
```
admin@lnos-x1-a-asw01:~$ date
Fri Jan 31 20:51:12 UTC 2020
admin@lnos-x1-a-asw01:~$ sudo config interface breakout Ethernet0 2x50G  -f -v -y

Final list of ports to be added :  
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-head', 'sonic-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Deleting Port: Ethernet2
Deleting Port: Ethernet3
Deleting Port: Ethernet0
Deleting Port: Ethernet1
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000024eb"
(empty list or set)
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000002517"
(empty list or set)
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000002493"
(empty list or set)
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000024bf"
(empty list or set)
Writing in Config DB
Breakout process got successfully completed.
admin@lnos-x1-a-asw01:~$ 
```


>>>>> Test with only -f & -l option 

```
admin@lnos-x1-a-asw01:~$ date
Fri Jan 31 20:52:06 UTC 2020
admin@lnos-x1-a-asw01:~$ sudo config interface breakout Ethernet0 4x25G  -f -l -v -y


Final list of ports to be added :  
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-head', 'sonic-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet0
Deleting Port: Ethernet2
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1']
Merge Default Config for ['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x100000000256c"
(empty list or set)
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000002543"
(empty list or set)
Writing in Config DB
Breakout process got successfully completed.
admin@lnos-x1-a-asw01:~$ 

```



>>>>> Change default config to create issue, so that addPorts fails, Make sure config DB is not updated.
Add wrong vlan in default config:
```
admin@lnos-x1-a-asw01:~/pc_testing_merge$ sudo cat /etc/sonic/default_config_db.json | grep -A 10 "Vlan555"
        "Vlan555": {
            "description": "wrong_vlan", 
            "members": [
                "Ethernet0", 
                "Ethernet2", 
                "Ethernet1"
            ]
        }
    }, 
    "VLAN_MEMBER": {
        "Vlan100|Ethernet0": {


admin@lnos-x1-a-asw01:~/pc_testing$ sonic-cfggen -d --print-data > before_dpb_config

[DPB will fail because new config is not correct]
admin@lnos-x1-a-asw01:~$ sudo config interface breakout Ethernet0 1x100G  -f -l -v -y


Loaded below Yang Models
['sonic-acl', 'sonic-head', 'sonic-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Deleting Port: Ethernet2
Deleting Port: Ethernet3
Deleting Port: Ethernet0
Deleting Port: Ethernet1
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet0']
Merge Default Config for ['Ethernet0']
libyang[0]: Missing required element "admin_status" in "VLAN_LIST". (path: /sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan555'])
Data Loading Failed
Missing required element "admin_status" in "VLAN_LIST".
Port Addition Failed
[ERROR] Port breakout Failed!!! Opting Out
Aborted!


admin@lnos-x1-a-asw01:~/pc_testing$ sonic-cfggen -d --print-data > after_dpb_config
admin@lnos-x1-a-asw01:~/pc_testing$ diff before_dpb_config after_dpb_config 
admin@lnos-x1-a-asw01:~/pc_testing$
```


>>>>>  Verify ASIC DB part, that Keys are deleted [Added a Test Code which runs redis-cli command]
```
Find dependecies for port Ethernet8
Find dependecies for port Ethernet9
Find dependecies for port Ethernet10
Find dependecies for port Ethernet11
Deleting Port: Ethernet8
Deleting Port: Ethernet9
Deleting Port: Ethernet10
Deleting Port: Ethernet11
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet8', 'Ethernet10']
Merge Default Config for ['Ethernet8', 'Ethernet10']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000000fd0"
(empty list or set)
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000000ff9"
(empty list or set)
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000001022"
(empty list or set)
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x100000000104b"
(empty list or set)
Writing in Config DB
Breakout process got successfully completed.
admin@lnos-x1-a-asw01:~$ 




Every 2.0s: sudo bcmcmd ps                                         lnos-x1-a-asw01: Mon Feb  3 05:46:58 2020

ps
                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No
       xe1( 69)  !ena   1     -       SW  No   Forward          None    D   None  9412    No
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No
       xe3( 71)  !ena   1     -       SW  No   Forward          None    D   None  9412    No
       xe4( 72)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      p
       xe5( 73)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      k
       xe6( 74)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No
       xe7( 75)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No
       xe8( 76)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No
       xe9( 77)  !ena   1     -       SW  No   Forward          None    D   None  9122    No
      xe10( 78)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No
      xe11( 79)  !ena   1     -       SW  No   Forward          None    D   None  9122    No
      xe12( 80)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No
      xe13( 81)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No





Loaded below Yang Models
['sonic-acl', 'sonic-head', 'sonic-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet8
Find dependecies for port Ethernet10
Deleting Port: Ethernet8
Deleting Port: Ethernet10
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet8', 'Ethernet9', 'Ethernet10', 'Ethernet11']
Merge Default Config for ['Ethernet8', 'Ethernet9', 'Ethernet10', 'Ethernet11']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000002379"
(empty list or set)
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000023a8"
(empty list or set)
Writing in Config DB
Breakout process got successfully completed.
admin@lnos-x1-a-asw01:~$ 


Every 2.0s: sudo bcmcmd ps                                         lnos-x1-a-asw01: Mon Feb  3 05:50:27 2020

ps
                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No
       xe1( 69)  !ena   1     -       SW  No   Forward          None    D   None  9412    No
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No
       xe3( 71)  !ena   1     -       SW  No   Forward          None    D   None  9412    No
       xe4( 72)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      p
       xe5( 73)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      k
       xe6( 74)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No
       xe7( 75)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No
       xe8( 76)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No
       xe9( 77)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No
      xe10( 78)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No
      xe11( 79)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No
      xe12( 80)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No
      xe13( 81)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No
```


**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

