### PR TITLE
[config_mgmt.py]: Redirect logs to syslog.

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -330,7 +330,7 @@ class configMgmt():
             defConfig = dict()
             if loadDefConfig:
                 defConfig = self.getDefaultConfig(ports)
-                syslog.syslog('Default Config for {}'.format(ports))
+                syslog.syslog('Default Config: {}'.format(defConfig))
 
             # get the latest Data Tree, save this in input config, since this
             # is our starting point now
@@ -760,7 +760,7 @@ def testRun_Delete_Add_Port(cmode, nmode, loadDef):
 
     except Exception as e:
         print(e)
-        print("\n***Port Breal Out Test Failed***\n")
+        print("\n***Port Break Out Test Failed***\n")
         return
 
     return


### PR DESCRIPTION
Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Redirect logs to syslog.

**- How I did it**
Using syslog library of Python.

**- How to verify it**
```
Ports to be added :
 {
    "Ethernet6": "25000",
    "Ethernet7": "25000",
    "Ethernet4": "25000",
    "Ethernet5": "25000"
}

After running Logic to limit the impact

Final list of ports to be deleted :
 {
    "Ethernet6": "50000",
    "Ethernet4": "50000"
}
Final list of ports to be added :
 {
    "Ethernet6": "25000",
    "Ethernet7": "25000",
    "Ethernet4": "25000",
    "Ethernet5": "25000"
}
Loaded below Yang Models
['sonic-port', 'sonic-vlan', 'sonic-extension', 'sonic-acl', 'sonic-head', 'sonic-portchannel', 'sonic-interface']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet6
Find dependecies for port Ethernet4
Deleting Port: Ethernet6
Deleting Port: Ethernet4
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
```

### no debug files are created:
```
admin@lnos-x1-a-fab01:~$ ls
config_mgmt.py       copy.sh               setup.py            _sonic_yang_ext.py_orig               sonic_yang.py
config_mgmt.py_orig  new_port_config.json  _sonic_yang_ext.py  sonic_yang_mgmt-1.0-py2-none-any.whl  sonic_yang.py_orig
admin@lnos-x1-a-fab01:~$
```

### Logs are in syslog file
```
Feb 20 19:21:17.511387 lnos-x1-a-fab01 INFO sonic_yang: module: sonic-port is loaded successfully
Feb 20 19:21:17.513233 lnos-x1-a-fab01 INFO sonic_yang: module: sonic-vlan is loaded successfully
Feb 20 19:21:17.514402 lnos-x1-a-fab01 INFO sonic_yang: module: sonic-extension is loaded successfully
Feb 20 19:21:17.517236 lnos-x1-a-fab01 INFO sonic_yang: module: sonic-acl is loaded successfully
Feb 20 19:21:17.518336 lnos-x1-a-fab01 INFO sonic_yang: module: sonic-head is loaded successfully
Feb 20 19:21:17.519530 lnos-x1-a-fab01 INFO sonic_yang: module: sonic-portchannel is loaded successfully
Feb 20 19:21:17.521190 lnos-x1-a-fab01 INFO sonic_yang: module: sonic-interface is loaded successfully
Feb 20 19:21:17.530684 lnos-x1-a-fab01 INFO sonic_yang: Parsed Json for sonic-port
Feb 20 19:21:17.546525 lnos-x1-a-fab01 INFO sonic_yang: Parsed Json for sonic-vlan
Feb 20 19:21:17.550267 lnos-x1-a-fab01 INFO sonic_yang: Parsed Json for sonic-extension
Feb 20 19:21:17.572507 lnos-x1-a-fab01 INFO sonic_yang: Parsed Json for sonic-acl
Feb 20 19:21:17.581072 lnos-x1-a-fab01 INFO sonic_yang: Parsed Json for sonic-head
Feb 20 19:21:17.589361 lnos-x1-a-fab01 INFO sonic_yang: Parsed Json for sonic-portchannel
Feb 20 19:21:17.599393 lnos-x1-a-fab01 INFO sonic_yang: Parsed Json for sonic-interface
Feb 20 19:21:17.798263 lnos-x1-a-fab01 INFO sonic_yang: xlateConfigDBtoYang sonic-port:sonic-port:sonic-port:PORT
Feb 20 19:21:17.799412 lnos-x1-a-fab01 INFO sonic_yang: xlateContainer listD PORT_LIST
Feb 20 19:21:17.812859 lnos-x1-a-fab01 INFO sonic_yang: Try to load Data in the tree
Feb 20 19:21:17.817427 lnos-x1-a-fab01 INFO config: delPorts ports:['Ethernet6', 'Ethernet4'] force:True
Feb 20 19:21:17.818246 lnos-x1-a-fab01 INFO config: Find dependecies for port Ethernet6
Feb 20 19:21:17.819247 lnos-x1-a-fab01 INFO config: Find dependecies for port Ethernet4
Feb 20 19:21:17.820678 lnos-x1-a-fab01 INFO config: Deleting Port:Ethernet6
Feb 20 19:21:17.821694 lnos-x1-a-fab01 INFO config: Deleting Port:Ethernet4
Feb 20 19:21:17.823193 lnos-x1-a-fab01 INFO config: Data Validation successful
Feb 20 19:21:17.826732 lnos-x1-a-fab01 INFO sonic_yang: revXlateYangtoConfigDB PORT
Feb 20 19:21:17.827965 lnos-x1-a-fab01 INFO sonic_yang: revXlateContainer PORT_LIST
Feb 20 19:21:17.829034 lnos-x1-a-fab01 INFO sonic_yang: revXlateList regex:<port_name>
Feb 20 19:21:17.843134 lnos-x1-a-fab01 INFO config: Start Port Addition
Feb 20 19:21:17.844129 lnos-x1-a-fab01 INFO config: addPorts ports:['Ethernet6', 'Ethernet7', 'Ethernet4', 'Ethernet5'] loadDefConfig:False
Feb 20 19:21:17.845211 lnos-x1-a-fab01 INFO config: addPorts Args portjson {'PORT': {'Ethernet6': {'alias': ' Eth2/3', 'admin_status': 'up', 'lanes': '71', 'speed': '25000', 'index': '2'},
'Ethernet7': {'alias': ' Eth2/4', 'admin_status': 'up', 'lanes': '72', 'speed': '25000', 'index': '2'}, 'Ethernet4': {'alias': 'Eth2/1', 'admin_status': 'up', 'lanes': '69', 'speed': '25000
', 'index': '2'}, 'Ethernet5': {'alias': ' Eth2/2', 'admin_status': 'up', 'lanes': '70', 'speed': '25000', 'index': '2'}}}
Feb 20 19:21:17.847045 lnos-x1-a-fab01 INFO sonic_yang: revXlateYangtoConfigDB PORT
Feb 20 19:21:17.847851 lnos-x1-a-fab01 INFO sonic_yang: revXlateContainer PORT_LIST
Feb 20 19:21:17.848565 lnos-x1-a-fab01 INFO sonic_yang: revXlateList regex:<port_name>
Feb 20 19:21:17.854805 lnos-x1-a-fab01 INFO sonic_yang: xlateConfigDBtoYang sonic-port:sonic-port:sonic-port:PORT
Feb 20 19:21:17.855946 lnos-x1-a-fab01 INFO sonic_yang: xlateContainer listD PORT_LIST
Feb 20 19:21:17.867419 lnos-x1-a-fab01 INFO sonic_yang: Try to load Data in the tree
Feb 20 19:21:17.872608 lnos-x1-a-fab01 INFO config: Data Validation successful
Feb 20 19:21:17.889988 fab01 NOTICE swss#portmgrd: :- doTask: Delete Port: Ethernet4
Feb 20 19:21:17.888973 lnos-x1-a-fab01 INFO config: Write in DB: {u'PORT': OrderedDict([(u'Ethernet4', None), (u'Ethernet6', None)])}
Feb 20 19:21:17.892697 fab01 NOTICE swss#portmgrd: :- doTask: Delete Port: Ethernet6
Feb 20 19:21:17.892849 fab01 NOTICE swss#orchagent: :- doPortTask: Deleting Port Ethernet4
Feb 20 19:21:17.893085 lnos-x1-a-fab01 INFO config: Verify Port Deletion from Asic DB, Wait...
Feb 20 19:21:17.893814 lnos-x1-a-fab01 INFO config: Check Asic DB: 1 try
Feb 20 19:21:17.895104 fab01 NOTICE swss#orchagent: :- deinitport: De-Initialized port Ethernet4
Feb 20 19:21:17.895203 fab01 NOTICE syncd#syncd: :- removePortDebugCounters: Trying to remove nonexisting port debug counter Ids 0x1000000001a75
Feb 20 19:21:17.895285 fab01 NOTICE swss#orchagent: :- doPortTask: Removing hostif d000000001a9d for Port Ethernet4
Feb 20 19:21:17.895363 fab01 NOTICE swss#orchagent: :- meta_port_remove_validation: all objects related to port oid:0x1000000001a75 are in default state, can be remove
Feb 20 19:21:17.895515 lnos-x1-a-fab01 INFO config: Check Key in Asic DB: ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000001a9e
Feb 20 19:21:17.895918 fab01 NOTICE swss#orchagent: :- post_port_remove: success executing post port remove actions: oid:0x1000000001a75
```

Build package:
```
pchaudha@e8879b00ab3e:/sonic$ make -f slave.mk target/python-debs/python-sonic-utilities_1.2-1_all.deb
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "broadcom"
"CONFIGURED_ARCH"                 : "amd64"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "1"
"SONIC_CONFIG_MAKE_JOBS"          : "24"
"SONIC_USE_DOCKER_BUILDKIT"       : ""
"USERNAME"                        : "admin"
"PASSWORD"                        : "YourPaSsWoRd"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "frr"
"FRR_USER_UID"                    : "300"
"FRR_USER_GID"                    : "300"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"ENABLE_SYSTEM_TELEMETRY"         : ""
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : ""
"BLDENV"                          : ""
"VS_PREPARE_MEM"                  : "yes"
"ENABLE_SFLOW"                    : "y"
```

Testing Commit 2:
```
ex': '1'}, 'Ethernet0': {'alias': 'Eth1/1', 'admin_status': 'up', 'lanes': '65', 'speed': '25000', 'index': '1'}, 'Ethernet1': {'alias': ' Et
h1/2', 'admin_status': 'up', 'lanes': '66', 'speed': '25000', 'index': '1'}}}
Mar  5 20:47:21.388033 lnos-x1-a-fab01 INFO config: Data Validation successful
Mar  5 20:47:21.404592 lnos-x1-a-fab01 INFO config: Write in DB: {u'PORT': OrderedDict([(u'Ethernet0', None), (u'Ethernet2', None)])}
Mar  5 20:47:21.407484 lnos-x1-a-fab01 INFO config: Verify Port Deletion from Asic DB, Wait...
Mar  5 20:47:21.408242 lnos-x1-a-fab01 INFO config: Check Asic DB: 1 try
Mar  5 20:47:21.411465 lnos-x1-a-fab01 INFO config: Check Key in Asic DB: ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000001d80
Mar  5 20:47:22.414320 lnos-x1-a-fab01 INFO config: Check Asic DB: 2 try
Mar  5 20:47:22.415762 lnos-x1-a-fab01 INFO config: Check Key in Asic DB: ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000001d80
Mar  5 20:47:22.416737 lnos-x1-a-fab01 INFO config: Check Key in Asic DB: ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000001d57
Mar  5 20:47:22.419557 lnos-x1-a-fab01 INFO config: Write in DB: {u'PORT': OrderedDict([('Ethernet0', {'alias': 'Eth1/1', 'admin_status': 'up
', 'lanes': '65', 'speed': '25000', 'index': '1'}), ('Ethernet1', {'alias': ' Eth1/2', 'admin_status': 'up', 'lanes': '66', 'speed': '25000',
 'index': '1'}), ('Ethernet2', {'alias': ' Eth1/3', 'admin_status': 'up', 'lanes': '67', 'speed': '25000', 'index': '1'}), ('Ethernet3', {'al
ias': ' Eth1/4', 'admin_status': 'up', 'lanes': '68', 'speed': '25000', 'index': '1'})])}
admin@lnos-x1-a-fab01:~$ ias': ' Eth1/4', 'admin_status': 'up', 'lanes': '68', 'speed': '25000', 'index': '1'})])}
admin@lnos-x1-a-fab01:~$ date
Thu Mar  5 20:50:51 UTC 2020
```


Testing Commit 4:

With INFO
```
Mar  6 00:34:56.548375 lnos-x1-a-fab01 INFO sonic_yang: xlateConfigDBtoYang sonic-port:sonic-port:sonic-port:PORT
Mar  6 00:34:56.549184 lnos-x1-a-fab01 INFO sonic_yang: xlateContainer listD PORT_LIST
Mar  6 00:34:56.549842 lnos-x1-a-fab01 INFO sonic_yang: xlateList regex:^(Ethernet[0-9]+)$ keyList:port_name
Mar  6 00:34:56.562087 lnos-x1-a-fab01 INFO sonic_yang: Try to load Data in the tree
Mar  6 00:34:56.567245 lnos-x1-a-fab01 INFO configMgmt: delPorts ports:['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1'] force:True
Mar  6 00:34:56.567995 lnos-x1-a-fab01 INFO configMgmt: Find dependecies for port Ethernet2
Mar  6 00:34:56.568903 lnos-x1-a-fab01 INFO configMgmt: Find dependecies for port Ethernet3
Mar  6 00:34:56.570332 lnos-x1-a-fab01 INFO configMgmt: Find dependecies for port Ethernet0
Mar  6 00:34:56.571833 lnos-x1-a-fab01 INFO configMgmt: Find dependecies for port Ethernet1
Mar  6 00:34:56.573972 lnos-x1-a-fab01 INFO configMgmt: Deleting Port:Ethernet2
Mar  6 00:34:56.575923 lnos-x1-a-fab01 INFO configMgmt: Deleting Port:Ethernet3
Mar  6 00:34:56.576891 lnos-x1-a-fab01 INFO configMgmt: Deleting Port:Ethernet0
Mar  6 00:34:56.577595 lnos-x1-a-fab01 INFO configMgmt: Deleting Port:Ethernet1
Mar  6 00:34:56.578505 lnos-x1-a-fab01 INFO configMgmt: Data Validation successful
Mar  6 00:34:56.581644 lnos-x1-a-fab01 INFO sonic_yang: revXlateYangtoConfigDB PORT
Mar  6 00:34:56.582337 lnos-x1-a-fab01 INFO sonic_yang: revXlateContainer PORT_LIST
Mar  6 00:34:56.583037 lnos-x1-a-fab01 INFO sonic_yang: revXlateList regex:<port_name>
Mar  6 00:34:56.597846 lnos-x1-a-fab01 INFO configMgmt: Start Port Addition
Mar  6 00:34:56.598800 lnos-x1-a-fab01 INFO configMgmt: addPorts ports:['Ethernet2', 'Ethernet0'] loadDefConfig:False
Mar  6 00:34:56.599554 lnos-x1-a-fab01 INFO configMgmt: addPorts Args portjson {'PORT': {'Ethernet2': {'alias': ' Eth1/3', 'admin_status': 'u
p', 'lanes': '67,68', 'speed': '50000', 'index': '1'}, 'Ethernet0': {'alias': 'Eth1/1', 'admin_status': 'up', 'lanes': '65,66', 'speed': '500
00', 'index': '1'}}}
Mar  6 00:34:56.601797 lnos-x1-a-fab01 INFO sonic_yang: revXlateYangtoConfigDB PORT
Mar  6 00:34:56.602463 lnos-x1-a-fab01 INFO sonic_yang: revXlateContainer PORT_LIST
Mar  6 00:34:56.603113 lnos-x1-a-fab01 INFO sonic_yang: revXlateList regex:<port_name>
Mar  6 00:34:56.609980 lnos-x1-a-fab01 INFO sonic_yang: xlateConfigDBtoYang sonic-port:sonic-port:sonic-port:PORT
Mar  6 00:34:56.611954 lnos-x1-a-fab01 INFO sonic_yang: xlateContainer listD PORT_LIST
Mar  6 00:34:56.615211 lnos-x1-a-fab01 INFO sonic_yang: xlateList regex:^(Ethernet[0-9]+)$ keyList:port_name
Mar  6 00:34:56.623598 lnos-x1-a-fab01 INFO sonic_yang: Try to load Data in the tree
Mar  6 00:34:56.626422 lnos-x1-a-fab01 INFO configMgmt: Data Validation successful
Mar  6 00:34:56.646266 lnos-x1-a-fab01 INFO configMgmt: Write in DB: {u'PORT': OrderedDict([(u'Ethernet0', None), (u'Ethernet1', None), (u'Et
hernet2', None), (u'Ethernet3', None)])}
```



With DEBUG:
```
    "Ethernet2": "50000",
    "Ethernet0": "50000"
}
Final list of ports to be added :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
Loaded below Yang Models
['sonic-port', 'sonic-vlan', 'sonic-extension', 'sonic-acl', 'sonic-head', 'sonic-portchannel', 'sonic-interface']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet0
Deleting Port: Ethernet2
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000001f6c"
(empty list or set)
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000001f43"
(empty list or set)
Writing in Config DB
Breakout process got successfully completed.
```

```
Mar  6 00:37:06.249923 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList vkey speed
Mar  6 00:37:06.250460 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList vkey alias
Mar  6 00:37:06.251029 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList Extract pkey:Ethernet41
Mar  6 00:37:06.251628 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList vkey index
Mar  6 00:37:06.252208 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList vkey admin_status
Mar  6 00:37:06.253655 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList vkey lanes
Mar  6 00:37:06.254322 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList vkey speed
Mar  6 00:37:06.254994 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList vkey alias
Mar  6 00:37:06.255558 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList Extract pkey:Ethernet40
Mar  6 00:37:06.256074 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList vkey index
Mar  6 00:37:06.256624 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList vkey admin_status
Mar  6 00:37:06.257141 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList vkey lanes
Mar  6 00:37:06.257682 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList vkey speed
Mar  6 00:37:06.258221 lnos-x1-a-fab01 DEBUG sonic_yang: xlateList vkey alias
Mar  6 00:37:06.258845 lnos-x1-a-fab01 INFO sonic_yang: Try to load Data in the tree
Mar  6 00:37:06.259633 lnos-x1-a-fab01 INFO configMgmt: Data Validation successful
Mar  6 00:37:06.260274 lnos-x1-a-fab01 DEBUG configMgmt: if_name_map {'Ethernet126': '1000000001758', 'Ethernet124': '100000000172f', 'Ethern
et122': '1000000001706', 'Ethernet120': '10000000016dd', 'Ethernet76': '1000000001595', 'Ethernet77': '10000000015be', 'Ethernet74': '1000000
001543', 'Ethernet75': '100000000156c', 'Ethernet72': '10000000014f1', 'Ethernet73': '100000000151a', 'Ethernet70': '100000000149f', 'Etherne
t71': '10000000014c8', 'Ethernet78': '10000000015e7', 'Ethernet79': '1000000001610'
```




**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

