### PR TITLE
platform.json changes to use list for modes

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -107,7 +107,7 @@ def _get_option(ctx,args,incomplete):
         if interface_name in breakout_file_input[INTF_KEY]:
             breakout_mode_list = [v["breakout_modes"] for i ,v in breakout_file_input[INTF_KEY].items() if i == interface_name][0]
             breakout_mode_options = []
-            for i in breakout_mode_list.split(','):
+            for i in breakout_mode_list:
                     breakout_mode_options.append(i)
             all_mode_options = [str(c) for c in breakout_mode_options if incomplete in c]
             return all_mode_options


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>


**- What I did**
Once, the datatype of "breakout_modes" get changed from string to list, this code will be compatible with the changes. 
> Needed change all the platform.json files in sonic-buildimage device folder.
dependent PR: [sonic-buildimage#70](https://github.com/zhenggen-xu/sonic-buildimage/pull/70)
```
"breakout_modes": "1x100G[40G], 2x50G, 4x25G[10G], 2x25G(2)+1x50G(2), 1x50G(2)+2x25G(2)"
```
into this:
```
"breakout_modes": ["1x100G[40G]", "2x50G", "4x25G[10G]", "2x25G(2)+1x50G(2)", "1x50G(2)+2x25G(2)" ]
```
**- How I did it**

**- How to verify it**
```
admin@lnos-x1-a-csw07:~$ sudo config interface breakout Ethernet0
1x100G[40G]  2x50G        4x25G[10G]
admin@lnos-x1-a-csw07:~$ sudo config interface breakout Ethernet0 2x50G -l -y

Running Breakout Mode : 1x100G[40G]
Target Breakout Mode : 2x50G

Ports to be deleted :
 {
    "Ethernet0": "100000"
}
Ports to be added :
 {
    "Ethernet2": "50000",
    "Ethernet0": "50000"
}

After running Logic to limit the impact

Final list of ports to be deleted :
 {
    "Ethernet0": "100000"
}
Final list of ports to be added :
 {
    "Ethernet2": "50000",
    "Ethernet0": "50000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet0
Dependecies Exist. No further action will be taken
*** Printing dependecies ***
/sonic-interface:sonic-interface/INTERFACE/INTERFACE_LIST[port_name='Ethernet0']/port_name
/sonic-interface:sonic-interface/INTERFACE/INTERFACE_IPPREFIX_LIST[port_name='Ethernet0'][ip-prefix='10.0.0.0/31']/port_name
/sonic-interface:sonic-interface/INTERFACE/INTERFACE_IPPREFIX_LIST[port_name='Ethernet0'][ip-prefix='2000:1:1::2/126']/port_name
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

