### PR TITLE
[config_mgmt.py]: Separate class for Dy Port BreakOut and support ext…

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -36,18 +36,17 @@ DEFAULT_CONFIG_DB_JSON_FILE = '/etc/sonic/port_breakout_config_db.json'
 # Class to handle config managment for SONIC, this class will use PLY to verify
 # config for the commands which are capable of change in config DB.
 
-class configMgmt():
+class ConfigMgmt():
 
-    def __init__(self, source="configDB", debug=False, allowExtraTables=True):
+    def __init__(self, source="configDB", debug=False, allowTablesWithOutYang=True):
 
         try:
             self.configdbJsonIn = None
             self.configdbJsonOut = None
-            self.allowExtraTables = allowExtraTables
-            self.oidKey = 'ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x'
+            self.allowTablesWithOutYang = allowTablesWithOutYang
 
             # logging vars
-            self.SYSLOG_IDENTIFIER = "configMgmt"
+            self.SYSLOG_IDENTIFIER = "ConfigMgmt"
             self.DEBUG = debug
 
             self.sy = sonic_yang.sonic_yang(YANG_DIR, debug=debug)
@@ -60,17 +59,57 @@ class configMgmt():
             else:
                 self.readConfigDBJson(source)
             # this will crop config, xlate and load.
-            self.sy.load_data(self.configdbJsonIn, self.allowExtraTables)
+            self.sy.load_data(self.configdbJsonIn)
+
+            # Raise if tables without YANG models are not allowed but exist.
+            if not allowTablesWithOutYang and len(self.sy.tablesWithOutYang):
+                raise Exception('Config has tables without YANG models')
 
         except Exception as e:
             print(e)
-            raise(Exception('configMgmt Class creation failed'))
+            raise(Exception('ConfigMgmt Class creation failed'))
 
         return
 
     def __del__(self):
         pass
 
+    """
+    Return tables loaded in config for which YANG model does not exist.
+    """
+    def tablesWithOutYang(self):
+
+        return self.sy.tablesWithOutYang
+
+    """
+    Explicit function to load config data in Yang Data Tree
+    """
+    def loadData(self, configdbJson):
+        self.sy.load_data(configdbJson)
+        # Raise if tables without YANG models are not allowed but exist.
+        if not self.allowTablesWithOutYang and len(self.sy.tablesWithOutYang):
+            raise Exception('Config has tables without YANG models')
+
+        return
+
+        """
+    Validate current Data Tree
+    """
+    def validateConfigData(self):
+
+        try:
+            self.sy.validate_data_tree()
+        except Exception as e:
+            self.sysLog(msg='Data Validation Failed')
+            return False
+
+        print('Data Validation successful')
+        self.sysLog(msg='Data Validation successful')
+        return True
+
+    """
+    syslog Support
+    """
     def sysLog(self, debug=syslog.LOG_INFO, msg=None):
 
         # log debug only if enabled
@@ -125,6 +164,30 @@ class configMgmt():
         configdb.mod_config(FormatConverter.output_to_db(data))
 
         return
+
+# End of Class ConfigMgmt
+
+"""
+    Config MGMT class for Dynamic Port Breakout(DPB).
+    This is derived from ConfigMgmt.
+"""
+class ConfigMgmtDPB(ConfigMgmt):
+
+    def __init__(self, source="configDB", debug=False, allowTablesWithOutYang=True):
+
+        try:
+            ConfigMgmt.__init__(self, source=source, debug=debug, \
+                allowTablesWithOutYang=allowTablesWithOutYang)
+            self.oidKey = 'ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x'
+
+        except Exception as e:
+            print(e)
+            raise(Exception('ConfigMgmtDPB Class creation failed'))
+
+        return
+
+    def __del__(self):
+        pass
 
     """
       Check if a key exists in ASIC DB or not.
@@ -359,7 +422,7 @@ class configMgmt():
 
             # create a tree with merged config and validate, if validation is
             # sucessful, then configdbJsonOut contains final and valid config.
-            self.sy.load_data(self.configdbJsonOut, self.allowExtraTables)
+            self.sy.load_data(self.configdbJsonOut)
             if self.validateConfigData()==False:
                 return configToLoad, False
 
@@ -449,54 +512,74 @@ class configMgmt():
         return D1
 
     """
+    search Relevant Keys in Config using DFS, This function is mainly
+    used to search port related config in Default ConfigDbJson file.
+    In: Config to be searched
+    skeys: Keys to be searched in In Config i.e. search Keys.
+    Out: Contains the search result
+    """
+    def searchKeysInConfig(self, In, Out, skeys):
+
+        found = False
+        if isinstance(In, dict):
+            for key in In.keys():
+                #print("key:" + key)
+                for skey in skeys:
+                    # pattern is very specific to current primary keys in
+                    # config DB, may need to be updated later.
+                    pattern = '^' + skey + '\|' + '|' + skey + '$' + \
+                        '|' + '^' + skey + '$'
+                    #print(pattern)
+                    reg = re.compile(pattern)
+                    #print(reg)
+                    if reg.search(key):
+                        # In primary key, only 1 match can be found, so return
+                        # print("Added key:" + key)
+                        Out[key] = In[key]
+                        found = True
+                        break
+                # Put the key in Out by default, if not added already.
+                # Remove later, if subelements does not contain any port.
+                if Out.get(key) is None:
+                    Out[key] = type(In[key])()
+                    if self.searchKeysInConfig(In[key], Out[key], skeys) == False:
+                        del Out[key]
+                    else:
+                        found = True
+
+        elif isinstance(In, list):
+            for skey in skeys:
+                if skey in In:
+                    found = True
+                    Out.append(skey)
+                    #print("Added in list:" + port)
+
+        else:
+            # nothing for other keys
+            pass
+
+        return found
+
+    """
+    This function returns the relavant keys in Input Config.
+    For Example: All Ports related Config in Config DB.
+    """
+    def configWithKeys(self, configIn=dict(), keys=list()):
+
+        configOut = dict()
+        try:
+            if len(configIn) and len(keys):
+                self.searchKeysInConfig(configIn, configOut, skeys=keys)
+        except Exception as e:
+            print("configWithKeys Failed, Error: {}".format(str(e)))
+            raise e
+
+        return configOut
+
+    """
     Create a defConfig for given Ports from Default Config File.
     """
     def getDefaultConfig(self, ports=list()):
-
-        """
-        create Default Config using DFS for all ports
-        """
-        def createDefConfig(In, Out, ports):
-
-            found = False
-            if isinstance(In, dict):
-                for key in In.keys():
-                    #print("key:" + key)
-                    for port in ports:
-                        # pattern is very specific to current primary keys in
-                        # config DB, may need to be updated later.
-                        pattern = '^' + port + '\|' + '|' + port + '$' + \
-                            '|' + '^' + port + '$'
-                        #print(pattern)
-                        reg = re.compile(pattern)
-                        #print(reg)
-                        if reg.search(key):
-                            # In primary key, only 1 match can be found, so return
-                            # print("Added key:" + key)
-                            Out[key] = In[key]
-                            found = True
-                            break
-                    # Put the key in Out by default, if not added already.
-                    # Remove later, if subelements does not contain any port.
-                    if Out.get(key) is None:
-                        Out[key] = type(In[key])()
-                        if createDefConfig(In[key], Out[key], ports) == False:
-                            del Out[key]
-                        else:
-                            found = True
-
-            elif isinstance(In, list):
-                for port in ports:
-                    if port in In:
-                        found = True
-                        Out.append(port)
-                        #print("Added in list:" + port)
-
-            else:
-                # nothing for other keys
-                pass
-
-            return found
 
         # function code
         try:
@@ -504,10 +587,9 @@ class configMgmt():
             defConfigIn = readJsonFile(DEFAULT_CONFIG_DB_JSON_FILE)
             #print(defConfigIn)
             defConfigOut = dict()
-            createDefConfig(defConfigIn, defConfigOut, ports)
+            self.searchKeysInConfig(defConfigIn, defConfigOut, skeys=ports)
         except Exception as e:
-            print("Get Default Config Failed")
-            print(e)
+            print("getDefaultConfig Failed, Error: {}".format(str(e)))
             raise e
 
         return defConfigOut
@@ -520,13 +602,12 @@ class configMgmt():
             # Get the Diff
             print('Generate Final Config to write in DB')
             configDBdiff = self.diffJson()
-
             # Process diff and create Config which can be updated in Config DB
             configToLoad = self.createConfigToLoad(configDBdiff, \
                 self.configdbJsonIn, self.configdbJsonOut)
 
         except Exception as e:
-            print("Update to Config DB Failed")
+            print("Config Diff Generation failed")
             print(e)
             raise e
 
@@ -657,7 +738,7 @@ class configMgmt():
         from jsondiff import diff
         return diff(self.configdbJsonIn, self.configdbJsonOut, syntax='symmetric')
 
-# end of config_mgmt class
+# end of class ConfigMgmtDPB
 
 """
     Test Functions:
@@ -774,7 +855,7 @@ def testRun_Delete_Add_Port(cmode, nmode, loadDef):
     # TODO: Verify config in Config DB  after writing to config DB.
     print('Test Run Break Out Ports')
     try:
-        cm = configMgmt('configDB', debug=True)
+        cm = ConfigMgmtDPB(source='configDB', debug=True)
 
         delPorts = delPortDict[cmode]
         addPorts = delPortDict[nmode]

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -59,11 +59,7 @@ class ConfigMgmt():
             else:
                 self.readConfigDBJson(source)
             # this will crop config, xlate and load.
-            self.sy.load_data(self.configdbJsonIn)
-
-            # Raise if tables without YANG models are not allowed but exist.
-            if not allowTablesWithOutYang and len(self.sy.tablesWithOutYang):
-                raise Exception('Config has tables without YANG models')
+            self.loadData(self.configdbJsonIn)
 
         except Exception as e:
             print(e)
@@ -422,7 +418,7 @@ class ConfigMgmtDPB(ConfigMgmt):
 
             # create a tree with merged config and validate, if validation is
             # sucessful, then configdbJsonOut contains final and valid config.
-            self.sy.load_data(self.configdbJsonOut)
+            self.loadData(self.configdbJsonOut)
             if self.validateConfigData()==False:
                 return configToLoad, False
 

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -92,7 +92,7 @@ class ConfigMgmt():
 
         return
 
-        """
+    """
     Validate current Data Tree
     """
     def validateConfigData(self):

--- a/config/main.py
+++ b/config/main.py
@@ -16,7 +16,7 @@ import ipaddress
 from swsssdk import ConfigDBConnector
 from swsssdk import SonicV2Connector
 from minigraph import parse_device_desc_xml
-from config_mgmt import configMgmt
+from config_mgmt import ConfigMgmt, ConfigMgmtDPB
 
 import aaa
 import mlnx
@@ -144,16 +144,36 @@ def _validate_interface_mode(ctx, BREAKOUT_CFG_FILE, interface_name, target_brko
         sys.exit(0)
     return True
 
-def load_configMgmt(verbose):
+def load_ConfigMgmt(verbose):
     """ Load config for the commands which are capable of change in config DB. """
     try:
-        # TODO: set allowExtraTables to False, i.e we should have yang models for
-        # each table in Config. [TODO: Create Yang model for each Table]
-        # cm = configMgmt(debug=verbose, allowExtraTables=False)
-        cm = configMgmt(debug=verbose, allowExtraTables=True)
+        cm = ConfigMgmtDPB(debug=verbose)
         return cm
     except Exception as e:
         raise Exception("Failed to load the config. Error: {}".format(str(e)))
+
+"""
+Funtion to warn user about extra tables while Dynamic Port Breakout(DPB).
+confirm: re-confirm from user to proceed.
+Config Tables Without Yang model considered extra tables.
+cm =  instance of config MGMT class.
+"""
+def breakout_warnUser_extraTables(cm, final_delPorts, confirm=True):
+
+    try:
+        # check if any extra tables exist
+        eTables = cm.tablesWithOutYang()
+        if len(eTables):
+            # find relavent tables in extra tables, i.e. one which can have deleted
+            # ports
+            tables = cm.configWithKeys(configIn=eTables, keys=final_delPorts)
+            click.secho("Below Config can not be verified, It may cause harm "\
+                "to the system\n {}".format(json.dumps(tables, indent=2)))
+            click.confirm('Do you wish to Continue?', abort=True)
+    except Exception as e:
+        raise Exception("Failed in breakout_warnUser_extraTables. Error: {}".format(str(e)))
+
+    return
 
 def breakout_Ports(cm, delPorts=list(), addPorts=list(), portJson=dict(), \
     force=False, loadDefConfig=True, verbose=False):
@@ -657,7 +677,7 @@ def load(filename, yes, disable_validation):
     # Verify config before config load
     if not disable_validation:
         try:
-            cm = configMgmt(source=filename)
+            cm = ConfigMgmt(source=filename)
             if cm.validateConfigData()==False:
                 raise(Exception('Config Validation Failed'))
         except Exception as e:
@@ -692,7 +712,7 @@ def reload(filename, yes, load_sysinfo, disable_validation):
     # Verify config before stoping service
     if not disable_validation:
         try:
-            cm = configMgmt(source=filename)
+            cm = ConfigMgmt(source=filename)
             if cm.validateConfigData()==False:
                 raise(Exception('Config Validation Failed'))
         except Exception as e:
@@ -1703,11 +1723,14 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
     # Start Interation with Dy Port BreakOut Config Mgmt
     try:
         """ Load config for the commands which are capable of change in config DB """
-        cm = load_configMgmt(verbose)
+        cm = load_ConfigMgmt(verbose)
 
-        """ Delete all ports if forced else print dependencies using configMgmt API """
+        """ Delete all ports if forced else print dependencies using ConfigMgmt API """
         final_delPorts = [intf for intf in del_intf_dict.keys()]
-        """ Add ports with its attributes using configMgmt API """
+        """ Warn user if tables without yang models exist and have final_delPorts """
+        breakout_warnUser_extraTables(cm, final_delPorts, confirm=True)
+        # prompt
+        """ Add ports with its attributes using ConfigMgmt API """
         final_addPorts = [intf for intf in port_dict.keys()]
         portJson = dict(); portJson['PORT'] = port_dict
         # breakout_Ports will abort operation on failure, So no need to check return


### PR DESCRIPTION
…ra config tables listing.

Changes:
1.) Added a new class for ConfigMgmtDPB, which is derived from ConfigMgmt.
2.) Support to list extra tables in config.
3.) Search keys in config. This is need to list port related config in extra tables.
4.) Separate loadData function in ConfigMgmt class.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

1.) Added a new class for ConfigMgmtDPB, which is derived from ConfigMgmt.
2.) Support to list extra tables in config.
3.) Search keys in config. This is need to list port related config in extra tables.
4.) Separate loadData function in ConfigMgmt class.

**- How I did it**
0.) https://github.com/zhenggen-xu/sonic-buildimage/pull/69 to store extra tables.
1.) Added a new class for ConfigMgmtDPB, which is derived from ConfigMgmt.
2.) Support to list extra tables in config.
3.) Search keys in config. This is need to list port related config in extra tables.
4.) Separate loadData function in ConfigMgmt class.

**- How to verify it**
Ran below Tests 
```
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 4x25G 
Target Breakout Mode : 2x50G

Ports to be deleted : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}
Ports to be added : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
} 
Final list of ports to be added :  
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "4x25G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Deleting Port: Ethernet2
Deleting Port: Ethernet3
Deleting Port: Ethernet0
Deleting Port: Ethernet1
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet2', 'Ethernet0']
Merge Default Config for ['Ethernet2', 'Ethernet0']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
:::Lock Released:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet5  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe1( 69)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe3( 71)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe4( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe6( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 2x50G 
Target Breakout Mode : 1x100G

Ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Ports to be added : 
 {
    "Ethernet0": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
} 
Final list of ports to be added :  
 {
    "Ethernet0": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "2x50G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet0
Dependecies Exist. No further action will be taken
*** Printing dependecies ***
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan100']/members[.='Ethernet2']
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan777']/members[.='Ethernet2']
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan100'][port='Ethernet2']/port
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan777'][port='Ethernet2']/port
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan100']/members[.='Ethernet0']
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan777']/members[.='Ethernet0']
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan100'][port='Ethernet0']/port
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan777'][port='Ethernet0']/port
:::Lock PID: None and self.pid:29100:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet5  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  !ena   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe1( 69)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe2( 70)  !ena   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe3( 71)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe4( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe6( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 2x50G 
Target Breakout Mode : 1x100G

Ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Ports to be added : 
 {
    "Ethernet0": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
} 
Final list of ports to be added :  
 {
    "Ethernet0": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "2x50G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet0
Deleting Port: Ethernet2
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
:::Lock Released:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet4  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet5  | untagged       |                       |
|           | fe80::1/10             | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       ce0( 68)  down   4  100G  FD   SW  No   Forward          None    D    KR4  9412    No      
       xe0( 69)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe1( 70)  !ena   2     -       SW  No   Forward          None    D   None  9412    No      
       xe2( 71)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe3( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe4( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 1x100G 
Target Breakout Mode : 4x25G

Ports to be deleted : 
 {
    "Ethernet0": "100000"
}
Ports to be added : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet0": "100000"
} 
Final list of ports to be added :  
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "1x100G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet0
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
:::Lock Released:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet4  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet5  | untagged       |                       |
|           | fe80::1/10             | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   1   25G  FD   SW  No   Forward          None    D     KR  9412    No      
       xe1( 69)  down   1   25G  FD   SW  No   Forward          None    D     KR  9412    No      
       xe2( 70)  down   1   25G  FD   SW  No   Forward          None    D     KR  9412    No      
       xe3( 71)  down   1   25G  FD   SW  No   Forward          None    D     KR  9412    No      
       xe4( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe6( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 4x25G 
Target Breakout Mode : 1x100G

Ports to be deleted : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}
Ports to be added : 
 {
    "Ethernet0": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
} 
Final list of ports to be added :  
 {
    "Ethernet0": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "4x25G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Deleting Port: Ethernet2
Deleting Port: Ethernet3
Deleting Port: Ethernet0
Deleting Port: Ethernet1
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
:::Lock Released:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet4  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet5  | untagged       |                       |
|           | fe80::1/10             | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       ce0( 68)  down   4  100G  FD   SW  No   Forward          None    D    KR4  9412    No      
       xe0( 69)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe1( 70)  !ena   2     -       SW  No   Forward          None    D   None  9412    No      
       xe2( 71)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe3( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe4( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 1x100G 
Target Breakout Mode : 2x50G

Ports to be deleted : 
 {
    "Ethernet0": "100000"
}
Ports to be added : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet0": "100000"
} 
Final list of ports to be added :  
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "1x100G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet0
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet2', 'Ethernet0']
Merge Default Config for ['Ethernet2', 'Ethernet0']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
:::Lock Released:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet5  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe1( 69)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe3( 71)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe4( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe6( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 2x50G 
Target Breakout Mode : 4x25G

Ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Ports to be added : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
} 
Final list of ports to be added :  
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "2x50G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet0
Deleting Port: Ethernet2
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1']
Merge Default Config for ['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
:::Lock Released:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet1  | untagged       |                       |
|           | fe80::1/10             | Ethernet2  | untagged       |                       |
|           |                        | Ethernet3  | untagged       |                       |
|           |                        | Ethernet4  | untagged       |                       |
|           |                        | Ethernet5  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe1( 69)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe2( 70)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe3( 71)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe4( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe6( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      

```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

