### PR TITLE
[config_mgmt.py]: Set leaf-list to empty list while port breakout.

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -530,12 +530,15 @@ class configMgmt():
             # if output is dict, delete keys from config
             if isinstance(inp, dict):
                 for key in diff:
-                    #print(key)
                     # make sure keys from diff are present in inp but not in outp
                     # then delete it.
                     if key in inp and key not in outp:
-                        # assign key to None(null), redis will delete entire key
-                        config[key] = None
+                        if type(inp[key]) == list:
+                            # assign current lists as empty.
+                            config[key] = []
+                        else:
+                            # assign key to None(null), redis will delete entire key
+                            config[key] = None
                     else:
                         # log such keys
                         print("Diff: Probably wrong key: {}".format(key))


### PR DESCRIPTION
Changes:
-- Set leaf-list to empty list while port breakout, This can be done only when
   yang models have default value set in them. Since as of now we delete a node
   in data tree only while DPB, we are good with this fix.
   In future. We may have to find default value while node deletion in sonic_yang
   library.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Changes:
-- Set leaf-list to empty list while port breakout, This can be done only when
   yang models have default value set in them. Since as of now we delete a node
   in data tree only while DPB, we are good with this fix.
   In future. We may have to find default value while node deletion in sonic_yang
   library.


**- How I did it**
Added default value as empty list after adding default value in yang models.

**- How to verify it**
```
Default value leaf-list testing:


============================== 1 tests deselected ==============================
=================== 1 passed, 1 deselected in 93.69 seconds ====================
svc-lnos-user@server10:/home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests$ cat test_port_dpb_system.py | grep -A 4 -B 4 Uncomment

        # Verify port is removed from ACL table
        self.dvs_acl.verify_acl_table_count(1)

        #TBD: Uncomment this, or explain why Ethernet0 is being added back to ACL table
        # Also, string "None" is being added as port to ACL port list after the breakout
        self.dvs_acl.verify_acl_group_num(0)

        # Verify child ports are created.
svc-lnos-user@server10:/home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests$ sudo pytest --dvsname=vs-jk test_port_dpb_system.py -k test_port_breakout_with_acl --junitxml=report.xml | tee out
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.3.0, py-1.6.0, pluggy-0.6.0
rootdir: /home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 2 items

test_port_dpb_system.py .                                                [100%]

 generated xml file: /home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests/report.xml
============================== 1 tests deselected ==============================
=================== 1 passed, 1 deselected in 94.25 seconds ====================
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**
```
Final list of ports to be added :
 {
    "Ethernet2": "50000",
    "Ethernet0": "50000"
}
Loaded below Yang Models
['sonic-vlan', 'sonic-portchannel', 'sonic-acl', 'sonic-port', 'sonic-extension', 'sonic-head', 'sonic-loopback-interface', 'sonic-interface']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Deleting Port: Ethernet2
Deleting Port: Ethernet3
Deleting Port: Ethernet0
Deleting Port: Ethernet1
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
```
