### PR TITLE
Enable extra table test

### DIFF
--- a/sonic-utilities-tests/config_mgmt_test.py
+++ b/sonic-utilities-tests/config_mgmt_test.py
@@ -32,7 +32,7 @@ class TestConfigMgmt(TestCase):
         self.updateConfig(curConfig, unknown)
         self.writeJson(curConfig, config_mgmt.CONFIG_DB_JSON_FILE)
         cm = config_mgmt.ConfigMgmt(source=config_mgmt.CONFIG_DB_JSON_FILE)
-        #assert "unknown_table" in cm.tablesWithoutYang()
+        assert "unknown_table" in cm.tablesWithOutYang()
         return
 
     def test_search_keys(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
   [sonic-utilities-tests/config_mgmt_test.py]: Enable test for extra table in config.

    After merging https://github.com/zhenggen-xu/sonic-buildimage/pull/69
    enabling test for extra table in config.

    Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com
**- How I did it**

**- How to verify it**
Build again.
```
pchaudha@server05:/home/pchaudha/srcCode/dpb_repo$ date
Tue Jun 30 15:13:36 PDT 2020
pchaudha@server05:/home/pchaudha/srcCode/dpb_repo$ ls -l target/python-debs/python-sonic-utilities_1.2-1_all.deb
-rw-r--r-- 1 pchaudha pchaudha 153218 Jun 30 15:08 target/python-debs/python-sonic-utilities_1.2-1_all.deb
pchaudha@server05:/home/pchaudha/srcCode/dpb_repo$
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

