### PR TITLE
Extra lock table

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -117,6 +117,24 @@ class ConfigMgmt():
 
         return
 
+    def _filterTablesInConfig(self, config):
+        """
+            Check if any table should not be considered in Input Config, remove
+            such table from Input Config.
+            Parameters:
+                config(dict): Input Config
+            Returns:
+                void
+        """
+        # nonConfigTables should not be considered in Input Config.
+        nonConfigTables = ['LOCK']
+        for t in nonConfigTables:
+            if t in config.keys():
+                self.sysLog(msg='Filtering {}'.format(t))
+                del config[t]
+
+        return
+
     def readConfigDBJson(self, source=CONFIG_DB_JSON_FILE):
 
         print('Reading data from {}'.format(source))
@@ -125,7 +143,7 @@ class ConfigMgmt():
         if not self.configdbJsonIn:
             raise(Exception("Can not load config from config DB json file"))
         self.sysLog(msg='Reading Input {}'.format(self.configdbJsonIn))
-
+        self._filterTablesInConfig(self.configdbJsonIn)
         return
 
     """
@@ -143,7 +161,7 @@ class ConfigMgmt():
         self.configdbJsonIn =  FormatConverter.to_serialized(data)
         self.sysLog(syslog.LOG_DEBUG, 'Reading Input from ConfigDB {}'.\
             format(self.configdbJsonIn))
-
+        self._filterTablesInConfig(self.configdbJsonIn)
         return
 
     def writeConfigDB(self, jDiff):

--- a/config/main.py
+++ b/config/main.py
@@ -163,7 +163,7 @@ def breakout_warnUser_extraTables(cm, final_delPorts, confirm=True):
     try:
         # check if any extra tables exist
         eTables = cm.tablesWithOutYang()
-        if eTables == None or len(eTables) == 0:
+        if len(eTables) == 0:
             return
         # let user know that extra tables exist in config
         click.secho("Below Table(s) can not be verified using YANG models:")
@@ -171,7 +171,7 @@ def breakout_warnUser_extraTables(cm, final_delPorts, confirm=True):
         # find relavent tables in extra tables, i.e. one which can have deleted
         # ports
         tables = cm.configWithKeys(configIn=eTables, keys=final_delPorts)
-        if tables != None and len(tables):
+        if len(tables):
             click.secho("Below Config in Unverified Table(s) may harm the system")
             click.secho("{}".format(json.dumps(tables, indent=2)))
             # Need to confirm if extra Tables have any deleted ports.

--- a/config/main.py
+++ b/config/main.py
@@ -163,12 +163,18 @@ def breakout_warnUser_extraTables(cm, final_delPorts, confirm=True):
     try:
         # check if any extra tables exist
         eTables = cm.tablesWithOutYang()
-        if len(eTables):
-            # find relavent tables in extra tables, i.e. one which can have deleted
-            # ports
-            tables = cm.configWithKeys(configIn=eTables, keys=final_delPorts)
-            click.secho("Below Config can not be verified, It may cause harm "\
-                "to the system\n {}".format(json.dumps(tables, indent=2)))
+        if eTables == None or len(eTables) == 0:
+            return
+        # let user know that extra tables exist in config
+        click.secho("Below Table(s) can not be verified using YANG models:")
+        click.secho("{}".format(eTables.keys()))
+        # find relavent tables in extra tables, i.e. one which can have deleted
+        # ports
+        tables = cm.configWithKeys(configIn=eTables, keys=final_delPorts)
+        if tables != None and len(tables):
+            click.secho("Below Config in Unverified Table(s) may harm the system")
+            click.secho("{}".format(json.dumps(tables, indent=2)))
+            # Need to confirm if extra Tables have any deleted ports.
             click.confirm('Do you wish to Continue?', abort=True)
     except Exception as e:
         raise Exception("Failed in breakout_warnUser_extraTables. Error: {}".format(str(e)))
@@ -671,7 +677,7 @@ class ConfigDbLock():
                 log_debug(":::Lock Acquired:::")
             # if lock exists but expire timer not running, run expire time and
             # abort.
-            elif not self.client.ttl(self.lockName):
+            elif self.client.ttl(self.lockName) == -1:
                 self.client.expire(self.lockName, self.timeout)
                 click.echo(":::Can not acquire lock, Reset Timer & Abort:::");
                 sys.exit(1)

--- a/sonic-utilities-tests/config_mgmt_test.py
+++ b/sonic-utilities-tests/config_mgmt_test.py
@@ -81,9 +81,10 @@ class TestConfigMgmt(TestCase):
         curConfig = dict(configDbJson)
         lock = {"LOCK": {"configDbLock": {"PID": "15555"}}}
         self.updateConfig(curConfig, lock)
+        prevLen = len(curConfig)
         cm = self.config_mgmt_dpb(curConfig)
         # Assert LOCK is removed from Input Config
-        assert len(cm.configdbJsonIn) == 5 and \
+        assert (len(cm.configdbJsonIn) ==  prevLen-1) and \
             'LOCK' not in cm.configdbJsonIn.keys()
         # Test by direct Call
         prevLen = len(curConfig)

--- a/sonic-utilities-tests/config_mgmt_test.py
+++ b/sonic-utilities-tests/config_mgmt_test.py
@@ -76,6 +76,22 @@ class TestConfigMgmt(TestCase):
         self.dpb_port4_4x25G_2x50G_f_l(curConfig)
         return
 
+    def test_extra_tables_cases(self):
+        # make sure no prompt with LOCK
+        curConfig = dict(configDbJson)
+        lock = {"LOCK": {"configDbLock": {"PID": "15555"}}}
+        self.updateConfig(curConfig, lock)
+        cm = self.config_mgmt_dpb(curConfig)
+        # Assert LOCK is removed from Input Config
+        assert len(cm.configdbJsonIn) == 5 and \
+            'LOCK' not in cm.configdbJsonIn.keys()
+        # Test by direct Call
+        prevLen = len(curConfig)
+        cm._filterTablesInConfig(curConfig)
+        assert (len(curConfig) == prevLen-1) and 'LOCK' not in curConfig.keys()
+
+        return
+
     def tearDown(self):
         try:
             os.remove(config_mgmt.CONFIG_DB_JSON_FILE)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

    [config/main.py]: Filter LOCK table from input config while config validation\DPB.

    Changes:
    -- Filter LOCK table from input config while config validation\DPB.
    -- lock ttl check should be -1.
    -- Ask for confirmation from user while DPB only when deleted ports
       exists in extra tables[i.e without YANG].

**- How I did it**
    -- Filter LOCK table from input config while config validation\DPB.
    -- lock ttl check should be -1.
    -- Ask for confirmation from user while DPB only when deleted ports
       exists in extra tables[i.e without YANG].

**- How to verify it**
Build with new tests:
```
make[1]: Leaving directory '/home/pchaudha/srcCode/dpb_repo'
pchaudha@server05:/home/pchaudha/srcCode/dpb_repo$ ls -l target/python-debs/python-sonic-utilities_1.2-1_all.deb
-rw-r--r-- 1 pchaudha pchaudha 153560 Jul 20 17:34 target/python-debs/python-sonic-utilities_1.2-1_all.deb
pchaudha@server05:/home/pchaudha/srcCode/dpb_repo$ date
Mon Jul 20 17:47:05 PDT 2020
```

Tests on DUT:
-- Without Port Eth4 in extra tables

```

Running Breakout Mode : 1x100G 
Target Breakout Mode : 2x50G

Ports to be deleted : 
 {
    "Ethernet4": "100000"
}
Ports to be added : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet4": "100000"
} 
Final list of ports to be added :  
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE']

Start Port Deletion
Find dependecies for port Ethernet4
Deleting Port: Ethernet4
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet6', 'Ethernet4']
Merge Default Config for ['Ethernet6', 'Ethernet4']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe4( 72)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe5( 73)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe6( 74)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      

Running Breakout Mode : 2x50G 
Target Breakout Mode : 1x100G

Ports to be deleted : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}
Ports to be added : 
 {
    "Ethernet4": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
} 
Final list of ports to be added :  
 {
    "Ethernet4": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE']

Start Port Deletion
Find dependecies for port Ethernet6
Find dependecies for port Ethernet4
Dependecies Exist. No further action will be taken
*** Printing dependecies ***
/sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V4']/ports[.='Ethernet6']
/sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V6']/ports[.='Ethernet6']
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan100'][port='Ethernet6']/port
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan777'][port='Ethernet6']/port
/sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V4']/ports[.='Ethernet4']
/sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V6']/ports[.='Ethernet4']
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan100'][port='Ethernet4']/port
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan777'][port='Ethernet4']/port
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe4( 72)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe5( 73)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe6( 74)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      

Running Breakout Mode : 2x50G 
Target Breakout Mode : 1x100G

Ports to be deleted : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}
Ports to be added : 
 {
    "Ethernet4": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
} 
Final list of ports to be added :  
 {
    "Ethernet4": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE']

Start Port Deletion
Find dependecies for port Ethernet6
Find dependecies for port Ethernet4
Deleting Port: Ethernet6
Deleting Port: Ethernet4
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
|           |                        | Ethernet11 | untagged       |                       |
|           |                        | Ethernet12 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       ce0( 72)  down   4  100G  FD   SW  No   Forward          None    D    KR4  9412    No      
       xe4( 73)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe5( 74)  !ena   2     -       SW  No   Forward          None    D   None  9412    No      

Running Breakout Mode : 1x100G 
Target Breakout Mode : 4x25G

Ports to be deleted : 
 {
    "Ethernet4": "100000"
}
Ports to be added : 
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet4": "100000"
} 
Final list of ports to be added :  
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE']

Start Port Deletion
Find dependecies for port Ethernet4
Deleting Port: Ethernet4
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
|           |                        | Ethernet11 | untagged       |                       |
|           |                        | Ethernet12 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe4( 72)  down   1   25G  FD   SW  No   Forward          None    D     KR  9412    No      
       xe5( 73)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe6( 74)  down   1   25G  FD   SW  No   Forward          None    D     KR  9412    No      

Running Breakout Mode : 4x25G 
Target Breakout Mode : 1x100G

Ports to be deleted : 
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
}
Ports to be added : 
 {
    "Ethernet4": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
} 
Final list of ports to be added :  
 {
    "Ethernet4": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE']

Start Port Deletion
Find dependecies for port Ethernet6
Find dependecies for port Ethernet7
Find dependecies for port Ethernet4
Find dependecies for port Ethernet5
Deleting Port: Ethernet6
Deleting Port: Ethernet7
Deleting Port: Ethernet4
Deleting Port: Ethernet5
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
|           |                        | Ethernet11 | untagged       |                       |
|           |                        | Ethernet12 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       ce0( 72)  down   4  100G  FD   SW  No   Forward          None    D    KR4  9412    No      
       xe4( 73)  !ena   1     -       SW  No   Forward          None   FA   None  9122    No      
       xe5( 74)  !ena   2     -       SW  No   Forward          None    D   None  9412    No      

Running Breakout Mode : 1x100G 
Target Breakout Mode : 2x50G

Ports to be deleted : 
 {
    "Ethernet4": "100000"
}
Ports to be added : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet4": "100000"
} 
Final list of ports to be added :  
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE']

Start Port Deletion
Find dependecies for port Ethernet4
Deleting Port: Ethernet4
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet6', 'Ethernet4']
Merge Default Config for ['Ethernet6', 'Ethernet4']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe4( 72)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe5( 73)  !ena   1     -       SW  No   Forward          None   FA   None  9122    No      
       xe6( 74)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      

Running Breakout Mode : 2x50G 
Target Breakout Mode : 4x25G

Ports to be deleted : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}
Ports to be added : 
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
} 
Final list of ports to be added :  
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE']

Start Port Deletion
Find dependecies for port Ethernet6
Find dependecies for port Ethernet4
Deleting Port: Ethernet6
Deleting Port: Ethernet4
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet6', 'Ethernet7', 'Ethernet4', 'Ethernet5']
Merge Default Config for ['Ethernet6', 'Ethernet7', 'Ethernet4', 'Ethernet5']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet5  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe4( 72)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe5( 73)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe6( 74)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      

```

-- With Port Eth4 in extra tables

```

Running Breakout Mode : 4x25G 
Target Breakout Mode : 2x50G

Ports to be deleted : 
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
}
Ports to be added : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
} 
Final list of ports to be added :  
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, UNKNOWN_TABLE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE', u'UNKNOWN_TABLE']
Below Config in Unverified Table(s) may harm the system
{
  "UNKNOWN_TABLE": {
    "TESTING": {
      "ports": [
        "Ethernet4"
      ]
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet6
Find dependecies for port Ethernet7
Find dependecies for port Ethernet4
Find dependecies for port Ethernet5
Deleting Port: Ethernet6
Deleting Port: Ethernet7
Deleting Port: Ethernet4
Deleting Port: Ethernet5
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet6', 'Ethernet4']
Merge Default Config for ['Ethernet6', 'Ethernet4']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe4( 72)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe5( 73)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe6( 74)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      

Running Breakout Mode : 2x50G 
Target Breakout Mode : 1x100G

Ports to be deleted : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}
Ports to be added : 
 {
    "Ethernet4": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
} 
Final list of ports to be added :  
 {
    "Ethernet4": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, UNKNOWN_TABLE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE', u'UNKNOWN_TABLE']
Below Config in Unverified Table(s) may harm the system
{
  "UNKNOWN_TABLE": {
    "TESTING": {
      "ports": [
        "Ethernet4"
      ]
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet6
Find dependecies for port Ethernet4
Dependecies Exist. No further action will be taken
*** Printing dependecies ***
/sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V4']/ports[.='Ethernet6']
/sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V6']/ports[.='Ethernet6']
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan100'][port='Ethernet6']/port
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan777'][port='Ethernet6']/port
/sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V4']/ports[.='Ethernet4']
/sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V6']/ports[.='Ethernet4']
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan100'][port='Ethernet4']/port
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan777'][port='Ethernet4']/port
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe4( 72)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe5( 73)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe6( 74)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      

Running Breakout Mode : 2x50G 
Target Breakout Mode : 1x100G

Ports to be deleted : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}
Ports to be added : 
 {
    "Ethernet4": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
} 
Final list of ports to be added :  
 {
    "Ethernet4": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, UNKNOWN_TABLE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE', u'UNKNOWN_TABLE']
Below Config in Unverified Table(s) may harm the system
{
  "UNKNOWN_TABLE": {
    "TESTING": {
      "ports": [
        "Ethernet4"
      ]
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet6
Find dependecies for port Ethernet4
Deleting Port: Ethernet6
Deleting Port: Ethernet4
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
|           |                        | Ethernet11 | untagged       |                       |
|           |                        | Ethernet12 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       ce0( 72)  down   4  100G  FD   SW  No   Forward          None    D    KR4  9412    No      
       xe4( 73)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe5( 74)  !ena   2     -       SW  No   Forward          None    D   None  9412    No      

Running Breakout Mode : 1x100G 
Target Breakout Mode : 4x25G

Ports to be deleted : 
 {
    "Ethernet4": "100000"
}
Ports to be added : 
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet4": "100000"
} 
Final list of ports to be added :  
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, UNKNOWN_TABLE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE', u'UNKNOWN_TABLE']
Below Config in Unverified Table(s) may harm the system
{
  "UNKNOWN_TABLE": {
    "TESTING": {
      "ports": [
        "Ethernet4"
      ]
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet4
Deleting Port: Ethernet4
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
|           |                        | Ethernet11 | untagged       |                       |
|           |                        | Ethernet12 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe4( 72)  down   1   25G  FD   SW  No   Forward          None    D     KR  9412    No      
       xe5( 73)  down   1   25G  FD   SW  No   Forward          None    D     KR  9412    No      
       xe6( 74)  down   1   25G  FD   SW  No   Forward          None    D     KR  9412    No      

Running Breakout Mode : 4x25G 
Target Breakout Mode : 1x100G

Ports to be deleted : 
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
}
Ports to be added : 
 {
    "Ethernet4": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
} 
Final list of ports to be added :  
 {
    "Ethernet4": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, UNKNOWN_TABLE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE', u'UNKNOWN_TABLE']
Below Config in Unverified Table(s) may harm the system
{
  "UNKNOWN_TABLE": {
    "TESTING": {
      "ports": [
        "Ethernet4"
      ]
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet6
Find dependecies for port Ethernet7
Find dependecies for port Ethernet4
Find dependecies for port Ethernet5
Deleting Port: Ethernet6
Deleting Port: Ethernet7
Deleting Port: Ethernet4
Deleting Port: Ethernet5
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
|           |                        | Ethernet11 | untagged       |                       |
|           |                        | Ethernet12 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       ce0( 72)  down   4  100G  FD   SW  No   Forward          None    D    KR4  9412    No      
       xe4( 73)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe5( 74)  !ena   2     -       SW  No   Forward          None    D   None  9412    No      

Running Breakout Mode : 1x100G 
Target Breakout Mode : 2x50G

Ports to be deleted : 
 {
    "Ethernet4": "100000"
}
Ports to be added : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet4": "100000"
} 
Final list of ports to be added :  
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, UNKNOWN_TABLE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE', u'UNKNOWN_TABLE']
Below Config in Unverified Table(s) may harm the system
{
  "UNKNOWN_TABLE": {
    "TESTING": {
      "ports": [
        "Ethernet4"
      ]
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet4
Deleting Port: Ethernet4
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet6', 'Ethernet4']
Merge Default Config for ['Ethernet6', 'Ethernet4']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe4( 72)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe5( 73)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe6( 74)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      

Running Breakout Mode : 2x50G 
Target Breakout Mode : 4x25G

Ports to be deleted : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
}
Ports to be added : 
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet6": "50000", 
    "Ethernet4": "50000"
} 
Final list of ports to be added :  
 {
    "Ethernet6": "25000", 
    "Ethernet7": "25000", 
    "Ethernet4": "25000", 
    "Ethernet5": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-crm', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, UNKNOWN_TABLE, 
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE', u'UNKNOWN_TABLE']
Below Config in Unverified Table(s) may harm the system
{
  "UNKNOWN_TABLE": {
    "TESTING": {
      "ports": [
        "Ethernet4"
      ]
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet6
Find dependecies for port Ethernet4
Deleting Port: Ethernet6
Deleting Port: Ethernet4
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet6', 'Ethernet7', 'Ethernet4', 'Ethernet5']
Merge Default Config for ['Ethernet6', 'Ethernet7', 'Ethernet4', 'Ethernet5']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet5  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe1( 69)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9122    No      
       xe3( 71)  !ena   1   25G  FD None  No   Disable          None   FA  XGMII  9412    No      
       xe4( 72)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe5( 73)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe6( 74)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      

```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

