### PR TITLE
[config/main.py]: Do not take lock for TABs or -h.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -722,7 +722,7 @@ class ConfigDbLock():
                 p.execute()
                 return
             else:
-                # some other process s holding the lock. Do nothing.
+                # some other process is holding the lock. Do nothing.
                 pass
             p.unwatch()
         except Exception as e:

--- a/config/main.py
+++ b/config/main.py
@@ -652,11 +652,9 @@ class ConfigDbLock():
         self.timeout = 10
         self.pid = os.getpid()
         self.client = None
-
-        self._acquireLock()
         return
 
-    def _acquireLock(self):
+    def acquireLock(self):
         try:
             # connect to db
             db_kwargs = dict()
@@ -722,15 +720,13 @@ class ConfigDbLock():
                 p.multi()
                 p.delete(self.lockName)
                 p.execute()
-                log_debug(":::Lock Released:::");
                 return
             else:
-                # some other process s holding the lock.
-                log_debug(":::Lock PID: {} and self.pid:{}:::".\
-                    format(p.hget(self.lockName, "PID"), self.pid))
+                # some other process s holding the lock. Do nothing.
+                pass
             p.unwatch()
         except Exception as e:
-            log_error("Exception: {}".format(e))
+            raise e
         return
 
     def __del__(self):
@@ -745,6 +741,10 @@ def config():
     """SONiC command line - 'config' command"""
     if os.geteuid() != 0:
         exit("Root privileges are required for this operation")
+    # Take lock only when config command is executed, to avoid taking lock for
+    # TABs and for -h. Note ? is treated as input python clicks
+    cdblock.acquireLock()
+
 config.add_command(aaa.aaa)
 config.add_command(aaa.tacacs)
 # === Add NAT Configuration ==========


### PR DESCRIPTION
  Changes:
    -- Take lock only when acquireLock() is called explicitly.
    -- Call acquireLock() in @config.
    -- Make function public.
    -- Can not use log_debug, log_error in destructor->releaseLock().
       because they may be destroyed already.
    -- Note: Test cannot be automated right now because of global code
       in config/main.py

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
  Changes:
    -- Take lock only when acquireLock() is called explicitly.
    -- Call acquireLock() in @config.
    -- Make function public.
    -- Can not use log_debug, log_error in destructor->releaseLock().
       because they may be destroyed already.
    -- Note: Test cannot be automated right now because of global code
       in config/main.py

**- How I did it**
  Changes:
    -- Take lock only when acquireLock() is called explicitly.
    -- Call acquireLock() in @config.
    -- Make function public.
    -- Can not use log_debug, log_error in destructor->releaseLock().
       because they may be destroyed already.
    -- Note: Test cannot be automated right now because of global code
       in config/main.py

**- How to verify it**
Press TAB and see no lock MSG
```
admin@lnos-x1-a-fab01:~/test_pc_load_yang$ sudo config 
aaa                    interface_naming_mode  portchannel            tacacs
acl                    load                   qos                    vlan
bgp                    load_mgmt_config       reload                 vrf
container              load_minigraph         route                  warm-restart
dropcounters           mirror-session         save                   watermark
ecn                    nat                    sflow                  ztp
feature                ntp                    snmpagentaddress       
hostname               pfcwd                  snmptrap               
interface              platform               syslog     

>> No MSG is seen.
```


Try with -h
```
admin@lnos-x1-a-fab01:~/test_pc_load_yang$ sudo config -h | more
Usage: config [OPTIONS] COMMAND [ARGS]...

  SONiC command line - 'config' command

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  aaa                    AAA command line
  acl                    ACL-related configuration tasks
  bgp                    BGP-related configuration tasks
  container              Modify configuration of containers
  dropcounters           Drop counter related configuration tasks
  ecn                    ECN-related configuration tasks
  feature                Configure status of feature
  hostname               Change device hostname without imp

admin@lnos-x1-a-fab01:~/test_pc_load_yang$ sudo config a
aaa  acl

>>> No LOCK MSG
```
Try full command:
```
admin@lnos-x1-a-fab01:~/test_pc_load_yang$ sudo config save 
Existing file will be overwritten, continue? [y/N]: y
Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json

Jul 21 18:35:04.511632 lnos-x1-a-fab01 DEBUG config: :::Lock Acquired:::
Jul 21 18:35:05.302662 lnos-x1-a-fab01 DEBUG config: :::Lock Timer Extended:::
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

